### PR TITLE
feat: implement apply json-pretty command

### DIFF
--- a/package.json
+++ b/package.json
@@ -437,6 +437,11 @@
         "command": "logmagnifier.removeMatchesWithSelection",
         "key": "ctrl+cmd+r",
         "when": "editorTextFocus && editorHasSelection"
+      },
+      {
+        "command": "logmagnifier.applyJsonPretty",
+        "key": "ctrl+cmd+j",
+        "when": "editorTextFocus"
       }
     ],
     "commands": [
@@ -947,6 +952,11 @@
         "command": "logmagnifier.removeMatchesWithSelection",
         "title": "Remove Lines Matching Selection",
         "icon": "$(trash)"
+      },
+      {
+        "command": "logmagnifier.applyJsonPretty",
+        "title": "Apply json-pretty on the line",
+        "category": "LogMagnifier"
       }
     ],
     "submenus": [
@@ -1160,7 +1170,12 @@
         {
           "command": "logmagnifier.removeMatchesWithSelection",
           "when": "editorHasSelection",
-          "group": "logmagnifier@4"
+          "group": "logmagnifier@5"
+        },
+        {
+          "command": "logmagnifier.applyJsonPretty",
+          "group": "logmagnifier@4",
+          "when": "editorTextFocus"
         }
       ],
       "view/item/context": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import { AdbCommandManager } from './services/AdbCommandManager';
 import { LogBookmarkService } from './services/LogBookmarkService';
 import { LogBookmarkWebviewProvider } from './views/LogBookmarkWebviewProvider';
 import { LogBookmarkCommandManager } from './services/LogBookmarkCommandManager';
+import { JsonPrettyService } from './services/JsonPrettyService';
 import { Constants } from './constants';
 
 export function activate(context: vscode.ExtensionContext) {
@@ -66,7 +67,8 @@ export function activate(context: vscode.ExtensionContext) {
 	setupExpansionSync(regexTreeView);
 
 	// Initialize Command Manager (Handles all command registrations)
-	new CommandManager(context, filterManager, highlightService, resultCountService, logProcessor, quickAccessProvider, logger, wordTreeView, regexTreeView);
+	const jsonPrettyService = new JsonPrettyService(logger);
+	new CommandManager(context, filterManager, highlightService, resultCountService, logProcessor, quickAccessProvider, logger, wordTreeView, regexTreeView, jsonPrettyService);
 
 	// ADB Devices
 	const adbService = new AdbService(logger);

--- a/src/services/CommandManager.ts
+++ b/src/services/CommandManager.ts
@@ -11,6 +11,7 @@ import { RegexUtils } from '../utils/RegexUtils';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { JsonPrettyService } from './JsonPrettyService';
 
 export class CommandManager {
     constructor(
@@ -22,7 +23,8 @@ export class CommandManager {
         private quickAccessProvider: QuickAccessProvider,
         private logger: Logger,
         private wordTreeView: vscode.TreeView<FilterGroup | FilterItem>,
-        private regexTreeView: vscode.TreeView<FilterGroup | FilterItem>
+        private regexTreeView: vscode.TreeView<FilterGroup | FilterItem>,
+        private jsonPrettyService: JsonPrettyService
     ) {
         this.registerCommands();
         // Initialize context key
@@ -336,6 +338,11 @@ export class CommandManager {
 
             await vscode.workspace.applyEdit(edits);
             vscode.window.showInformationMessage(`Removed ${matchCount} lines matching '${selectedText}'.`);
+        }));
+
+        // Command: Apply Json Pretty
+        this.context.subscriptions.push(vscode.commands.registerCommand('logmagnifier.applyJsonPretty', async () => {
+            await this.jsonPrettyService.execute();
         }));
 
         // Command: Toggle Group

--- a/src/services/JsonPrettyService.ts
+++ b/src/services/JsonPrettyService.ts
@@ -1,0 +1,225 @@
+import * as vscode from 'vscode';
+import { Logger } from './Logger';
+
+interface ExtractedJson {
+    type: 'valid' | 'invalid' | 'incomplete';
+    text: string;
+    parsed?: any;
+    error?: string;
+}
+
+export class JsonPrettyService {
+    constructor(private logger: Logger) { }
+
+    public async execute() {
+        try {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) {
+                return;
+            }
+
+            const selection = editor.selection;
+            let text = '';
+
+            if (!selection.isEmpty) {
+                text = editor.document.getText(selection);
+            } else {
+                text = editor.document.lineAt(selection.active.line).text;
+            }
+
+            if (!text || text.trim().length === 0) {
+                vscode.window.showInformationMessage('LogMagnifier: No text to process.');
+                return;
+            }
+
+            const jsons = this.extractJsons(text);
+            if (jsons.length === 0) {
+                vscode.window.showInformationMessage('LogMagnifier: No JSON-like content found in the selection.');
+                return;
+            }
+
+            const formattedContent = this.formatOutput(text, jsons);
+            const doc = await vscode.workspace.openTextDocument({
+                content: formattedContent,
+                language: 'jsonc'
+            });
+            await vscode.window.showTextDocument(doc);
+
+            this.logger.info(`JsonPrettyService: Processed ${jsons.length} objects.`);
+
+        } catch (error) {
+            this.logger.error(`JsonPrettyService error: ${error}`);
+            vscode.window.showErrorMessage('LogMagnifier: Error processing JSON.');
+        }
+    }
+
+    private extractJsons(text: string): ExtractedJson[] {
+        const found: ExtractedJson[] = [];
+        let startIndex = 0;
+
+        while (startIndex < text.length) {
+            const firstOpen = text.indexOf('{', startIndex);
+            if (firstOpen === -1) {
+                break;
+            }
+
+            const jsonCandidate = this.findBoundedJson(text, firstOpen);
+            if (jsonCandidate) {
+                if (!jsonCandidate.complete) {
+                    // Incomplete case
+                    found.push({
+                        type: 'incomplete',
+                        text: jsonCandidate.text
+                    });
+                    // Move past this block
+                    startIndex = jsonCandidate.endIndex + 1;
+                } else {
+                    // Potential complete block
+                    try {
+                        const parsed = JSON.parse(jsonCandidate.text);
+                        found.push({
+                            type: 'valid',
+                            text: jsonCandidate.text,
+                            parsed: parsed
+                        });
+                        startIndex = jsonCandidate.endIndex + 1;
+                    } catch (e) {
+                        // Invalid syntax case (but bounded)
+                        found.push({
+                            type: 'invalid',
+                            text: jsonCandidate.text,
+                            error: String(e)
+                        });
+                        startIndex = jsonCandidate.endIndex + 1;
+                    }
+                }
+            } else {
+                // Should not happen with new logic, but safe fallback
+                startIndex = firstOpen + 1;
+            }
+        }
+        return found;
+    }
+
+    private findBoundedJson(text: string, start: number): { text: string, endIndex: number, complete: boolean } | null {
+        let textIndex = start;
+        let braceCount = 0;
+        let inString = false;
+        let escape = false;
+
+        for (; textIndex < text.length; textIndex++) {
+            const char = text[textIndex];
+
+            if (escape) {
+                escape = false;
+                continue;
+            }
+
+            if (char === '\\') {
+                escape = true;
+                continue;
+            }
+
+            if (char === '"') {
+                inString = !inString;
+                continue;
+            }
+
+            if (!inString) {
+                if (char === '{') {
+                    braceCount++;
+                } else if (char === '}') {
+                    braceCount--;
+                    if (braceCount === 0) {
+                        return { text: text.substring(start, textIndex + 1), endIndex: textIndex, complete: true };
+                    }
+                }
+            }
+        }
+
+        // If we reach here, we have an incomplete JSON (braceCount > 0)
+        if (braceCount > 0) {
+            return { text: text.substring(start), endIndex: text.length, complete: false };
+        }
+
+        return null;
+    }
+
+    private formatOutput(original: string, jsons: ExtractedJson[]): string {
+        let output = original.trimRight() + '\n\n\n';
+
+        for (const item of jsons) {
+            if (item.type === 'valid') {
+                output += JSON.stringify(item.parsed, null, 2) + '\n\n';
+            } else if (item.type === 'invalid') {
+                output += '// [INVALID JSON]\n';
+                output += this.bestEffortFormat(item.text) + '\n\n';
+            } else if (item.type === 'incomplete') {
+                output += '// [INCOMPLETE JSON]\n';
+                output += this.bestEffortFormat(item.text) + '\n\n';
+            }
+        }
+        return output;
+    }
+
+    private bestEffortFormat(text: string): string {
+        let indent = 0;
+        let output = '';
+        let inString = false;
+        let quoteChar = '';
+        let escape = false;
+
+        for (let i = 0; i < text.length; i++) {
+            const char = text[i];
+
+            if (escape) {
+                output += char;
+                escape = false;
+                continue;
+            }
+
+            if (char === '\\') {
+                output += char;
+                escape = true;
+                continue;
+            }
+
+            if ((char === '"' || char === "'") && !inString) {
+                inString = true;
+                quoteChar = char;
+                output += char;
+                continue;
+            }
+
+            if (char === quoteChar && inString) {
+                inString = false;
+                output += char;
+                continue;
+            }
+
+            if (inString) {
+                output += char;
+                continue;
+            }
+
+            // Not in string
+            if (char === '{' || char === '[') {
+                indent++;
+                output += char + '\n' + '  '.repeat(indent);
+            } else if (char === '}' || char === ']') {
+                indent = Math.max(0, indent - 1);
+                output += '\n' + '  '.repeat(indent) + char;
+            } else if (char === ',') {
+                output += char + '\n' + '  '.repeat(indent);
+            } else if (char === ':') {
+                output += ': ';
+            } else if (char === ' ' || char === '\n' || char === '\r' || char === '\t') {
+                // Skip existing whitespace
+                continue;
+            } else {
+                output += char;
+            }
+        }
+        return output;
+    }
+}


### PR DESCRIPTION
Add new command 'Apply json-pretty on the line' to extract and format JSON strings from a log line.
- Support extraction of multiple JSON objects from a single line
- Handle invalid and incomplete JSON strings gracefully with best-effort formatting
- Add keyboard shortcut (Ctrl+Cmd+J) and context menu item