### PR TITLE
nav: enable jump to source from json-pretty view

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,7 +81,7 @@ export function activate(context: vscode.ExtensionContext) {
 	);
 
 	// Initialize Command Manager (Handles all command registrations)
-	const jsonPrettyService = new JsonPrettyService(logger);
+	const jsonPrettyService = new JsonPrettyService(logger, sourceMapService);
 	new CommandManager(context, filterManager, highlightService, resultCountService, logProcessor, quickAccessProvider, logger, wordTreeView, regexTreeView, jsonPrettyService, sourceMapService);
 
 	// ADB Devices


### PR DESCRIPTION
Integrate SourceMapService into JsonPrettyService. Register source mapping when generating the JSON view so users can navigate back to the original log line using 'Jump to Original Log Line' or Go to Definition.