### PR TITLE
ui: remove highlight navigation toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -310,11 +310,6 @@
             "default": false,
             "description": "Enable highlighting for Regex filters in the editor."
           },
-          "logmagnifier.editor.navigationAnimation": {
-            "type": "boolean",
-            "default": true,
-            "description": "Enable visual flash animation when navigating to search matches."
-          },
           "logmagnifier.regex.highlightColor": {
             "anyOf": [
               {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -103,7 +103,7 @@ export const Constants = {
         ToggleWordWrap: 'logmagnifier.toggleWordWrap',
         ToggleMinimap: 'logmagnifier.toggleMinimap',
         ToggleStickyScroll: 'logmagnifier.toggleStickyScroll',
-        ToggleNavigationAnimation: 'logmagnifier.toggleNavigationAnimation',
+
         ToggleOccurrencesHighlight: 'logmagnifier.toggleOccurrencesHighlight',
         ToggleFileSizeUnit: 'logmagnifier.toggleFileSizeUnit',
 
@@ -213,7 +213,6 @@ export const Constants = {
             WordWrap: 'wordWrap',
             MinimapEnabled: 'minimap.enabled',
             StickyScrollEnabled: 'stickyScroll.enabled',
-            NavigationAnimation: 'editor.navigationAnimation',
             RemoveMatchesMaxLines: 'removeMatches.maxLines',
             LargeFileOptimizations: 'largeFileOptimizations',
         },
@@ -278,7 +277,7 @@ export const Constants = {
         WordWrap: 'Word Wrap',
         Minimap: 'Minimap',
         StickyScroll: 'Sticky Scroll',
-        NavigationAnimation: 'Navigation Animation',
+
         OccurrencesHighlight: 'Occurrences Highlight',
         FileSize: 'File Size',
         Bytes: 'Bytes',

--- a/src/services/CommandManager.ts
+++ b/src/services/CommandManager.ts
@@ -618,12 +618,7 @@ export class CommandManager {
         });
 
 
-        this.context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.ToggleNavigationAnimation, async () => {
-            const config = vscode.workspace.getConfiguration(Constants.Configuration.Section);
-            const current = config.get<boolean>(Constants.Configuration.Editor.NavigationAnimation);
-            await config.update(Constants.Configuration.Editor.NavigationAnimation, !current, vscode.ConfigurationTarget.Global);
-            this.quickAccessProvider.refresh();
-        }));
+
 
 
         this.context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.CreateFilter, (item: any) => {

--- a/src/services/HighlightService.ts
+++ b/src/services/HighlightService.ts
@@ -387,12 +387,7 @@ export class HighlightService implements vscode.Disposable {
             return;
         }
 
-        const config = vscode.workspace.getConfiguration(Constants.Configuration.Section);
-        const enableAnimation = config.get<boolean>(Constants.Configuration.Editor.NavigationAnimation) || false;
 
-        if (!enableAnimation) {
-            return;
-        }
 
         // Cancel previous animation if active
         if (this.activeFlashTimeout) {

--- a/src/views/QuickAccessProvider.ts
+++ b/src/views/QuickAccessProvider.ts
@@ -36,14 +36,11 @@ export class QuickAccessProvider implements vscode.TreeDataProvider<vscode.TreeI
 
         const stickyScrollEnabled = config.get<boolean>('stickyScroll.enabled');
         Logger.getInstance().info(`Sticky Scroll state: ${stickyScrollEnabled}`);
-
-        const lmConfig = vscode.workspace.getConfiguration('logmagnifier', scope);
-
         return Promise.resolve([
             this.createButtonItem('Toggle Word Wrap', Constants.Commands.ToggleWordWrap, 'word-wrap'),
             this.createToggleItem(Constants.Labels.Minimap, !!minimapEnabled, Constants.Commands.ToggleMinimap, 'layout-sidebar-right'),
             this.createToggleItem(Constants.Labels.StickyScroll, !!stickyScrollEnabled, Constants.Commands.ToggleStickyScroll, 'pinned'),
-            this.createToggleItem(Constants.Labels.NavigationAnimation, !!lmConfig.get<boolean>(Constants.Configuration.Editor.NavigationAnimation), Constants.Commands.ToggleNavigationAnimation, 'eye'),
+
             this.createOccurrencesHighlightItem(config),
             this.createFileSizeItem(),
             this.createSeparator(),


### PR DESCRIPTION
Enable highlight navigation (animation) by default and remove the toggle option from the Quick Access view. This streamlines the UI as the feature is now permanently enabled.
Remove related configuration, constants, and command registration.