### PR TITLE
ci: add build and release workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,89 @@
+name: Build & Release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Set temporary version
+        if: github.ref_type != 'tag'
+        run: |
+          # Get current version using node
+          VERSION=$(node -p "require('./package.json').version")
+          
+          # Generate timestamp
+          TIMESTAMP=$(date +%Y%m%d%H%M%S)
+          
+          # New version
+          NEW_VERSION="${VERSION}-dev.${TIMESTAMP}"
+          
+          echo "Setting temporary version to $NEW_VERSION"
+          
+          # Update package.json using npm version to ensure file is updated correctly without git tag
+          npm version $NEW_VERSION --no-git-tag-version
+
+      - name: Package Extension
+        id: package_step
+        run: |
+          # Get package name and version
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          
+          # Define VSIX filename
+          VSIX_NAME="${PACKAGE_NAME}-${VERSION}.vsix"
+          echo "VSIX_NAME=$VSIX_NAME" >> $GITHUB_ENV
+          
+          # Package
+          npx @vscode/vsce package --out $VSIX_NAME
+
+      - name: Upload Artifact
+        id: upload_artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.VSIX_NAME }}
+          path: ${{ env.VSIX_NAME }}
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const artifactUrl = '${{ steps.upload_artifact.outputs.artifact-url }}';
+            const vsixName = '${{ env.VSIX_NAME }}';
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### 📦 Artifact Ready\n\nDownload the extension package here:\n[${vsixName}](${artifactUrl})`
+            })
+
+      - name: Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.VSIX_NAME }}


### PR DESCRIPTION
Implement automatic packaging and release workflow using GitHub Actions. This ensures that every push to main or PR triggers a build verification, and tags trigger a formal release with artifacts.

The workflow handles versioning by appending a timestamp for development builds and uses the exact tag version for releases. Artifacts are named using the pattern <package-name>-<version>.vsix for clarity.

Key changes:
- Add .github/workflows/package.yml configuration.
- Configure triggers for main branch, PRs, and tags.
- Implement dynamic artifact naming logic.