### PR TITLE
ci: fix fork PR artifacts permission issues

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -1,0 +1,48 @@
+name: Comment on PR
+
+on:
+  workflow_run:
+    workflows: ["Build & Release"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download PR Metadata'
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: pr_meta
+          path: pr_meta
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            
+            const prNumber = Number(fs.readFileSync('pr_meta/pr_number.txt', 'utf8').trim());
+            const artifactUrl = fs.readFileSync('pr_meta/artifact_url.txt', 'utf8').trim();
+            const vsixName = fs.readFileSync('pr_meta/vsix_name.txt', 'utf8').trim();
+            
+            if (!prNumber) {
+              console.log('No PR number found, skipping comment.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### 📦 Artifact Ready\n\nDownload the extension package here:\n[${vsixName}](${artifactUrl})`
+            });

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,10 +10,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   package:
     runs-on: ubuntu-latest
@@ -67,20 +63,20 @@ jobs:
           name: ${{ env.VSIX_NAME }}
           path: ${{ env.VSIX_NAME }}
 
-      - name: Comment on PR
+      - name: Save PR Metadata
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        run: |
+          mkdir -p pr_meta
+          echo "${{ github.event.number }}" > pr_meta/pr_number.txt
+          echo "${{ steps.upload_artifact.outputs.artifact-url }}" > pr_meta/artifact_url.txt
+          echo "${{ env.VSIX_NAME }}" > pr_meta/vsix_name.txt
+
+      - name: Upload PR Metadata
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const artifactUrl = '${{ steps.upload_artifact.outputs.artifact-url }}';
-            const vsixName = '${{ env.VSIX_NAME }}';
-            
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `### 📦 Artifact Ready\n\nDownload the extension package here:\n[${vsixName}](${artifactUrl})`
-            })
+          name: pr_meta
+          path: pr_meta/
 
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Refactor the CI/CD workflow to support pull requests from forked repositories. Forked PRs run with read-only permissions, preventing the direct posting of comments. This change splits the process into two workflows: one for building (unprivileged) and one for commenting (privileged).

Key changes:
- Remove commenting step from package.yml and export PR metadata.
- Add .github/workflows/comment-pr.yml to securely handle PR comments.
- Utilize workflow_run trigger to access write permissions for comments.