### PR TITLE
bookmark: remove back/forward navigation logic

### DIFF
--- a/src/views/LogBookmarkWebviewProvider.ts
+++ b/src/views/LogBookmarkWebviewProvider.ts
@@ -251,7 +251,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
         } catch (e) {
             this._view.webview.html = `<html><body><div style="padding: 20px; color: var(--vscode-errorForeground);">
                 Error loading bookmarks: ${e}<br/>
-                <button onclick="acquireVsCodeApi().postMessage({type: 'back'})">Try Back</button>
+                Error loading bookmarks: ${e}<br/>
             </div></body></html>`;
         }
     }
@@ -318,8 +318,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
                 </span>
             `).join('');
 
-            const canGoBack = (this._bookmarkService as any).canGoBack(uriStr);
-            const canGoForward = (this._bookmarkService as any).canGoForward(uriStr);
+
             const lineCount = (this._bookmarkService as any).getFileActiveLinesCount(uriStr);
 
 


### PR DESCRIPTION
Remove residual logic related to the deprecated back/forward navigation buttons in the bookmark feature. This includes removing history tracking maps (`_history`, `_historyIndices`) and associated methods (`back`, `forward`, `pushToHistory`) from LogBookmarkService.

Also clean up LogBookmarkWebviewProvider by removing unused variables and the dangling 'Try Back' button in the error fallback UI. Bookmark management now operates directly on the state map without history overhead.