### PR TITLE
chore: clean up whitespace, dead code, and stale comments

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -182,8 +182,6 @@ export const Constants = {
         CopyBookmarkFile: 'logmagnifier.copyBookmarkFile',
         OpenBookmarkFile: 'logmagnifier.openBookmarkFile',
         RemoveBookmarkGroup: 'logmagnifier.removeBookmarkGroup',
-
-        // ... (existing commands)
     },
 
     Views: {
@@ -410,8 +408,6 @@ export const Constants = {
         AdbPath: 'adb',
         AdbDefaultOptions: '-v threadtime',
     },
-
-    // Add other constants as needed
 } as const;
 
 export type FilterType = typeof Constants.FilterTypes.Include | typeof Constants.FilterTypes.Exclude;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -257,7 +257,6 @@ export function activate(context: vscode.ExtensionContext) {
 	}
 
 
-
 	// Update counts when text changes
 	context.subscriptions.push(vscode.workspace.onDidChangeTextDocument(e => {
 		if (vscode.window.activeTextEditor && e.document === vscode.window.activeTextEditor.document) {

--- a/src/models/Filter.ts
+++ b/src/models/Filter.ts
@@ -11,7 +11,7 @@ export interface FilterItem {
     highlightMode?: number; // 0: Word, 1: Line, 2: Full Line
     caseSensitive?: boolean;
     resultCount?: number;
-    contextLine?: number; // 0, 1, 3, 5, 10
+    contextLine?: number; // 0, 3, 5, 9
     excludeStyle?: 'line-through' | 'hidden'; // Default: line-through
 }
 

--- a/src/services/AdbService.ts
+++ b/src/services/AdbService.ts
@@ -579,7 +579,7 @@ export class AdbService {
                     this.logger.warn(`[ADB] Clear cache failed (might need debuggable app): ${err.message}`);
                     // We interpret 'run-as: package not debuggable' as a sort of failure but we resolve true so UI isn't blocked?
                     // actually resolve false to maybe warn user?
-                    // Detailed error often in stderr. 
+                    // Detailed error often in stderr.
                     resolve(false);
                     return;
                 }

--- a/src/services/CommandManager.ts
+++ b/src/services/CommandManager.ts
@@ -549,7 +549,6 @@ export class CommandManager {
         this.context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.SetFilterHighlightMode.Full, setHighlightModeHandler(2)));
 
 
-
         const toggleCaseSensitivityHandler = (item: FilterItem) => {
             const groups = this.filterManager.getGroups();
             let targetGroup = groups.find(g => g.filters.some(f => f.id === item.id));
@@ -603,7 +602,6 @@ export class CommandManager {
         this.context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.SetFilterContextLine.PlusMinus9, setContextLineHandler(9)));
 
 
-
         const changeColorHandler = async (item: any) => {
             const groups = this.filterManager.getGroups();
             let targetGroup = groups.find(g => g.filters.some(f => f.id === item.id));
@@ -641,15 +639,11 @@ export class CommandManager {
         this.context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.ChangeFilterColor.Prefix, changeColorHandler));
 
 
-
         // Register specific color commands to support specific tooltips
         const colorPresets = this.filterManager.getAvailableColors();
         colorPresets.forEach(colorId => {
             this.context.subscriptions.push(vscode.commands.registerCommand(`${Constants.Commands.ChangeFilterColor.Prefix}.${colorId}`, changeColorHandler));
         });
-
-
-
 
 
         this.context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.ToggleJsonPreview, async () => {

--- a/src/services/HighlightService.ts
+++ b/src/services/HighlightService.ts
@@ -306,7 +306,7 @@ export class HighlightService implements vscode.Disposable {
             // I'll keep it simple for now as requested.
 
             if (filter.isRegex) {
-                // Optimization: Avoid showing message repeatedly? 
+                // Optimization: Avoid showing message repeatedly?
                 // VS Code suppresses duplicate notifications usually.
                 vscode.window.showErrorMessage(
                     Constants.Messages.Error.InvalidFilterPattern.replace('{0}', filter.keyword),
@@ -386,7 +386,6 @@ export class HighlightService implements vscode.Disposable {
         if (!editor || line < 0) {
             return;
         }
-
 
 
         // Cancel previous animation if active

--- a/src/services/JsonPrettyService.ts
+++ b/src/services/JsonPrettyService.ts
@@ -145,7 +145,6 @@ export class JsonPrettyService {
             }
 
 
-
             // Update Tree View (Webview)
             // Prioritize valid JSONs, but fallback to lenient parsing for invalid ones
             // JSON Webview is now always enabled for this command
@@ -175,14 +174,13 @@ export class JsonPrettyService {
 
                 // Extract source info
                 const sourceUri = editor.document.uri.toString();
-                // If selection is single line, use that. 
+                // If selection is single line, use that.
                 // However, logProcessor extracted based on selection.active.line usually, or current line.
                 // Since this command uses active selection:
                 const sourceLine = selection.active.line;
 
                 this.jsonTreeWebview.show(results, 'JSON Preview', 'valid', tabSize, sourceUri, sourceLine, silent);
             }
-
 
 
         } catch (error) {
@@ -283,23 +281,6 @@ export class JsonPrettyService {
         }
 
         return null;
-    }
-
-    private formatOutput(original: string, jsons: ExtractedJson[]): string {
-        let output = original.trimRight() + '\n\n\n';
-
-        for (const item of jsons) {
-            if (item.type === 'valid') {
-                output += JSON.stringify(item.parsed, null, 2) + '\n\n';
-            } else if (item.type === 'invalid') {
-                output += '// [INVALID JSON]\n';
-                output += this.bestEffortFormat(item.text) + '\n\n';
-            } else if (item.type === 'incomplete') {
-                output += '// [INCOMPLETE JSON]\n';
-                output += this.bestEffortFormat(item.text) + '\n\n';
-            }
-        }
-        return output;
     }
 
     private bestEffortFormat(text: string): string {

--- a/src/services/LogBookmarkService.ts
+++ b/src/services/LogBookmarkService.ts
@@ -271,8 +271,6 @@ export class LogBookmarkService implements vscode.Disposable {
     }
 
 
-
-
     public getActiveLinesCount(): number {
         // Legacy/Global count: sum of all files
         let total = 0;
@@ -333,9 +331,6 @@ export class LogBookmarkService implements vscode.Disposable {
     }
 
     public getBookmarks(): Map<string, BookmarkItem[]> {
-        // Return a cleaner copy? Or just the map.
-        // For compatibility with previous map<string, BookmarkItem[]>, we can just return _bookmarks
-        // filtering is not needed if we assume _bookmarks is the source of truth.
         return this._bookmarks;
     }
 
@@ -353,10 +348,7 @@ export class LogBookmarkService implements vscode.Disposable {
     private updateDecorations(editor: vscode.TextEditor) {
         try {
             const key = editor.document.uri.toString();
-            // Reverted to using getBookmarks() to ensure consistency, though less efficient.
-            // TODO: Optimize this to single-file lookup once stability is confirmed.
-            const activeBookmarksMap = this.getBookmarks();
-            const activeBookmarks = activeBookmarksMap.get(key);
+            const activeBookmarks = this._bookmarks.get(key);
 
             if (activeBookmarks && activeBookmarks.length > 0) {
                 const ranges = activeBookmarks.map(b => new vscode.Range(b.line, 0, b.line, 0));

--- a/src/services/LogProcessor.ts
+++ b/src/services/LogProcessor.ts
@@ -195,7 +195,7 @@ export class LogProcessor {
                 }
             }
 
-            // Includes: OR logic between groups. 
+            // Includes: OR logic between groups.
             // If any group has include filters, we enter "include mode".
             if (group.includes.length > 0) {
                 anyIncludeDefined = true;
@@ -209,24 +209,12 @@ export class LogProcessor {
             }
         }
 
-        // Final determination: 
+        // Final determination:
         // 1. If no include filters are defined anywhere, we include everything (that wasn't excluded).
         // 2. If include filters are defined, we only include if at least ONE matched.
         const isMatched = !anyIncludeDefined || matchFound;
 
         return { isMatched, contextLines: maxContext };
-    }
-
-    /**
-     * Checks if a line matches filters and returns the required context lines.
-     * Legacy method: Wrapper around checkMatchCompiled for backward compatibility.
-     */
-    public checkMatch(line: string, groups: FilterGroup[]): { isMatched: boolean, contextLines: number } {
-        // Optimization: if we are calling this in a loop for many lines, it's better to use checkMatchCompiled
-        // with pre-compiled groups.
-        const activeGroups = groups.filter(g => g.isEnabled);
-        const compiled = this.compileGroups(activeGroups);
-        return this.checkMatchCompiled(line, compiled);
     }
 
 }

--- a/src/utils/EditorUtils.ts
+++ b/src/utils/EditorUtils.ts
@@ -7,7 +7,7 @@ export class EditorUtils {
     /**
      * Tries to resolve the active text editor, prioritizing the active tab for large files
      * to prevent falling back to incorrect visible editors.
-     * 
+     *
      * @param lastActiveEditor Optional fallback if no active editor is directly found
      * @param operationName Optional name of the operation for specific error messages (e.g. "add bookmark")
      * @returns The active text editor, or undefined if none found or file is too large

--- a/src/utils/RegexUtils.ts
+++ b/src/utils/RegexUtils.ts
@@ -1,11 +1,4 @@
 export class RegexUtils {
-    /**
-     * Creates a RegExp object safely.
-     * @param keyword The pattern or search text.
-     * @param isRegex Whether the keyword is a regex pattern.
-     * @param caseSensitive Whether the search should be case sensitive.
-     * @returns A RegExp object. Returns a match-nothing regex on error.
-     */
     private static cache: Map<string, RegExp> = new Map();
     private static readonly MAX_CACHE_SIZE = 500;
     private static readonly ESCAPE_REGEX = /[.*+?^${}()|[\]\\]/g;

--- a/src/views/AdbDeviceTreeProvider.ts
+++ b/src/views/AdbDeviceTreeProvider.ts
@@ -17,7 +17,7 @@ export class AdbDeviceTreeProvider implements vscode.TreeDataProvider<AdbTreeIte
     }
 
     public initialize() {
-        // Kept for backward compatibility or manual refresh if needed, 
+        // Kept for backward compatibility or manual refresh if needed,
         // but getChildren handles lazy load now.
         if (!this.initialized) {
             this.refreshDevices();

--- a/src/views/FilterTreeView.ts
+++ b/src/views/FilterTreeView.ts
@@ -181,7 +181,7 @@ export class FilterTreeDataProvider implements vscode.TreeDataProvider<TreeItem>
             return;
         }
 
-        // Item Reordering/Moving (activeItem is FilterItem) 
+        // Item Reordering/Moving (activeItem is FilterItem)
         // When we get here, activeItem is definitely NOT a group because of the check above.
         const activeFilterItem = activeItem as FilterItem;
 

--- a/src/views/JsonTreeWebview.ts
+++ b/src/views/JsonTreeWebview.ts
@@ -74,9 +74,9 @@ export class JsonTreeWebview {
                     --row-hover-bg: var(--vscode-list-hoverBackground);
                     --row-focus-bg: var(--vscode-list-activeSelectionBackground);
                     --row-focus-fg: var(--vscode-list-activeSelectionForeground);
-                    
+
                     /* Stronger highlights */
-                    --highlight-bg: #ea5c00; 
+                    --highlight-bg: #ea5c00;
                     --highlight-fg: #ffffff;
                     --current-match-bg: #007acc;
                     --current-match-fg: #ffffff;
@@ -121,7 +121,7 @@ export class JsonTreeWebview {
                     display: flex;
                     justify-content: flex-start;
                     align-items: center;
-                    flex-wrap: wrap; 
+                    flex-wrap: wrap;
                     gap: 8px;
                     padding-bottom: 8px;
                     border-bottom: 1px solid var(--vscode-widget-border);
@@ -153,7 +153,7 @@ export class JsonTreeWebview {
                     z-index: 20;
                     justify-content: flex-start;
                 }
-                
+
                 .search-wrapper {
                     position: relative;
                     display: flex;
@@ -177,7 +177,7 @@ export class JsonTreeWebview {
                 input[type="text"]:focus {
                     outline: 1px solid var(--vscode-focusBorder);
                 }
-                
+
                 .count-overlay {
                     position: absolute;
                     right: 6px;
@@ -194,7 +194,7 @@ export class JsonTreeWebview {
                     overflow: hidden;
                     text-overflow: ellipsis;
                 }
-                
+
                 .search-actions {
                     display: flex;
                     gap: 4px;
@@ -226,7 +226,7 @@ export class JsonTreeWebview {
                      padding: 5px 10px;
                      display: inline-block; /* revert flex center for text? or keep flex but auto width */
                 }
-                
+
                 button:hover {
                     background-color: var(--vscode-button-hoverBackground);
                 }
@@ -234,7 +234,7 @@ export class JsonTreeWebview {
                     opacity: 0.5;
                     cursor: not-allowed;
                 }
-                
+
                 input[type="number"]:focus {
                     outline: 1px solid var(--vscode-focusBorder);
                 }
@@ -263,13 +263,13 @@ export class JsonTreeWebview {
                     cursor: pointer;
                     font-size: 16px; /* Larger symbol */
                     font-weight: bold;
-                    border-radius: 0; 
+                    border-radius: 0;
                 }
-                
+
                 .depth-btn:hover {
                     background-color: var(--vscode-list-hoverBackground);
                 }
-                
+
                 .depth-btn:active {
                    background-color: var(--vscode-list-activeSelectionBackground);
                    color: var(--vscode-list-activeSelectionForeground);
@@ -290,12 +290,12 @@ export class JsonTreeWebview {
                 }
 
                 /* Text Label Buttons */
-                
+
                 .tree-root {
                     user-select: text; /* Allow selection */
                     padding-top: 4px;
                 }
-                
+
                 .text-block.compact-wrap {
                     white-space: pre-wrap;
                     word-break: break-all;
@@ -310,7 +310,7 @@ export class JsonTreeWebview {
                     white-space: pre-wrap; /* Allow wrapping if needed, but usually single line */
                     font-family: var(--vscode-editor-font-family);
                 }
-                
+
                 .tree-row:hover {
                     background-color: var(--row-hover-bg);
                 }
@@ -320,7 +320,7 @@ export class JsonTreeWebview {
                     color: var(--row-focus-fg);
                     outline: none;
                 }
-                
+
                 .arrow {
                     display: inline-block;
                     width: 20px;
@@ -332,21 +332,20 @@ export class JsonTreeWebview {
                     transition: transform 0.1s;
                     flex-shrink: 0;
                 }
-                
+
                 .arrow::before {
-                    content: '▶'; 
+                    content: '▶';
                     display: inline-block;
                     font-size: 12px;
                 }
-                
+
                 .expanded > .tree-row > .arrow::before {
                     transform: rotate(90deg);
                 }
-                
 
 
                 .leaf-spacer {
-                    width: 20px; 
+                    width: 20px;
                     display: inline-block;
                     flex-shrink: 0;
                 }
@@ -368,7 +367,7 @@ export class JsonTreeWebview {
                 .value.number { color: var(--number-color); }
                 .value.boolean { color: var(--boolean-color); }
                 .value.null { color: var(--null-color); }
-                
+
                 .focused .value { color: inherit; }
 
                 .meta {
@@ -376,7 +375,7 @@ export class JsonTreeWebview {
                     font-size: 0.9em;
                     margin-left: 5px;
                 }
-                
+
                 .children { display: none; }
                 .expanded > .children { display: block; }
 
@@ -420,7 +419,7 @@ export class JsonTreeWebview {
                 <button id="btn-toggle-view">Beautifier</button>
                 <button id="btn-reveal">Go to Definition</button>
             </div>
-            
+
             <div id="tree-container" class="tree-root" tabindex="0"></div>
             <div id="text-container" class="text-root" tabindex="0"></div>
 
@@ -456,11 +455,11 @@ export class JsonTreeWebview {
                 let sourceUri = '${sourceUri || ''}';
                 let sourceLine = ${sourceLine ?? -1};
                 let currentDepth = ${expansionDepth};
-                
+
                 let focusedRowDetails = null;
                 let isCompact = false;
                 let isTreeView = true;
-                
+
                 // Search State
                 let searchMatches = [];
                 let currentMatchIndex = -1;
@@ -477,7 +476,7 @@ export class JsonTreeWebview {
 
                 function render() {
                     treeContainer.innerHTML = '';
-                    
+
                     const items = getItems();
                     if (items.length === 0) return;
 
@@ -485,7 +484,7 @@ export class JsonTreeWebview {
                     items.forEach((item, index) => {
                         renderMultiRootItem(treeContainer, item.data, item.status, index + 1);
                     });
-                    
+
                     // Render Text
                     renderTextContainer();
                 }
@@ -503,10 +502,10 @@ export class JsonTreeWebview {
                 function renderTextItem(parent, data, text, status, index, rawData) {
                     const wrapper = document.createElement('div');
                     wrapper.style.marginBottom = '30px';
-                    wrapper.dataset.originalText = text; 
+                    wrapper.dataset.originalText = text;
                     // Store raw JSON if valid, to allow re-beautifying
-                    wrapper.dataset.jsonData = (status === 'valid' && rawData) ? JSON.stringify(rawData) : ''; 
-                    
+                    wrapper.dataset.jsonData = (status === 'valid' && rawData) ? JSON.stringify(rawData) : '';
+
                     const header = document.createElement('div');
                     header.style.marginBottom = '4px';
 
@@ -518,7 +517,7 @@ export class JsonTreeWebview {
 
                     const pre = document.createElement('div');
                     pre.className = 'text-block';
-                    
+
                     if (status === 'valid' && rawData) {
                          // Use rawData for correct structure
                          if (isCompact) {
@@ -589,40 +588,40 @@ export class JsonTreeWebview {
                      if (isTreeView) {
                         treeContainer.style.display = 'block';
                         textContainer.style.display = 'none';
-                        
+
                         const depthControl = document.querySelector('.depth-control');
-                        
+
                         // Toolbar State: Tree View
                         // Order: Expand, Collapse, Beautifier, Go to Definition
                         if (depthControl) depthControl.style.display = 'inline-flex';
-                        
+
                         btnCompact.style.display = 'none';
-                        
+
                         btnToggleView.textContent = 'Beautifier';
                         btnToggleView.style.display = 'inline-flex';
-                        
+
                         btnReveal.textContent = 'Go to Definition';
-                        btnReveal.style.display = 'inline-flex'; 
+                        btnReveal.style.display = 'inline-flex';
                         updateRecallButton(); // Will hide if no source
 
                         document.querySelector('.bottom-toolbar').style.display = 'flex';
                     } else {
                         const depthControl = document.querySelector('.depth-control');
-                        
+
                         // Toolbar State: Text View
-                         // If switching to Text View, ensure label is correct. 
+                         // If switching to Text View, ensure label is correct.
                          // isCompact state is preserved.
                          btnCompact.textContent = isCompact ? 'Beautifier' : 'Compact';
                          btnCompact.style.display = 'inline-flex';
-                        
+
                         treeContainer.style.display = 'none';
                         textContainer.style.display = 'block';
-                        
+
                         // Order: Compact (above), Preview, Go to Definition
                         btnToggleView.textContent = 'Preview';
-                        
+
                         if (depthControl) depthControl.style.display = 'none';
-                        
+
                         // Show Reveal (Go to Definition) in Text View as well
                         if (sourceUri && sourceLine >= 0) {
                              btnReveal.textContent = 'Go to Definition';
@@ -634,11 +633,11 @@ export class JsonTreeWebview {
                         document.querySelector('.bottom-toolbar').style.display = 'none';
                     }
                 }
-                
+
                 function toggleCompact() {
                     isCompact = !isCompact;
                     renderTextContainer();
-                    
+
                     if (isCompact) {
                         btnCompact.textContent = 'Beautifier';
                     } else {
@@ -658,33 +657,32 @@ export class JsonTreeWebview {
                     }
                     wrapper.style.marginBottom = '30px'; // Increased spacing
                     wrapper.style.borderLeft = 'none'; // Remove border
-                    
+
                     const header = document.createElement('div');
                     header.style.padding = '4px 0'; // Minimal padding
                     header.style.marginBottom = '4px';
-                    
+
                     // Status Badge for this item (No index, no arrow)
                     const badge = document.createElement('span');
                     badge.className = 'status-badge ' + (status === 'valid' ? 'status-valid' : 'status-invalid');
                     badge.textContent = status === 'valid' ? 'Valid JSON' : (status === 'no-json' ? 'No JSON' : 'Invalid JSON');
                     badge.style.marginRight = '0'; // Reset margin
                     header.appendChild(badge);
-                    
+
                     wrapper.appendChild(header);
-                    
+
                     if (status !== 'no-json') {
                         const content = document.createElement('div');
                         content.className = 'children';
-                        content.style.display = 'block'; 
-                        
+                        content.style.display = 'block';
+
                         // Root content is effectively at depth 0 relative to itself, but children start at 1
                         renderRootContent(content, data);
                         wrapper.appendChild(content);
                     }
-                    
+
                     parent.appendChild(wrapper);
                 }
-
 
 
                 function renderNode(parent, key, nodeData, depth, isRoot, isKeyError) {
@@ -697,7 +695,7 @@ export class JsonTreeWebview {
 
                     const node = document.createElement('div');
                     node.className = 'tree-node';
-                    
+
                     // Expand node if its depth is less than the current visible depth
                     if (depth < currentDepth) {
                         node.classList.add('expanded');
@@ -705,7 +703,7 @@ export class JsonTreeWebview {
 
                     const row = document.createElement('div');
                     row.className = 'tree-row';
-                    row.tabIndex = -1; 
+                    row.tabIndex = -1;
                     row.dataset.key = key;
                     row.style.paddingLeft = (depth * 20) + 'px';
 
@@ -730,16 +728,16 @@ export class JsonTreeWebview {
                     const keySpan = document.createElement('span');
                     keySpan.className = 'key';
                     if (isKeyError) keySpan.classList.add('error');
-                    
+
                     // Add brackets if array index
                     if (/^\\d+$/.test(key)) {
                             keySpan.textContent = '[' + key + ']';
                     } else {
                             keySpan.textContent = key;
                     }
-                    
+
                     row.appendChild(keySpan);
-                    
+
                     // Separator removed visually (display:none in CSS)
                     const sep = document.createElement('span');
                     sep.className = 'separator';
@@ -748,7 +746,7 @@ export class JsonTreeWebview {
 
                     if (!hasChildren) {
                         const valSpan = document.createElement('span');
-                        
+
                         valSpan.className = 'value ' + type;
                         if (isError) valSpan.classList.add('error');
 
@@ -757,7 +755,7 @@ export class JsonTreeWebview {
                         } else {
                             valSpan.textContent = String(value);
                         }
-                        
+
                         row.appendChild(valSpan);
                     } else {
                         if (isArray) {
@@ -772,7 +770,7 @@ export class JsonTreeWebview {
                         } else if (isObject) {
                              // Object meta? Usually just {}
                         }
-                        
+
                         if (isError) {
                              const errSpan = document.createElement('span');
                              errSpan.className = 'meta error';
@@ -786,7 +784,7 @@ export class JsonTreeWebview {
                     if (hasChildren) {
                         const childrenContainer = document.createElement('div');
                         childrenContainer.className = 'children';
-                        
+
                         if (isObject && nodeData.children) {
                             for (const child of nodeData.children) {
                                 renderNode(childrenContainer, child.key, child.value, depth + 1, false, child.isKeyError);
@@ -796,7 +794,7 @@ export class JsonTreeWebview {
                                 renderNode(childrenContainer, String(idx), item, depth + 1, false, false);
                             });
                         }
-                        
+
                         node.appendChild(childrenContainer);
                     }
 
@@ -807,7 +805,7 @@ export class JsonTreeWebview {
                     node.classList.toggle('expanded');
                     focusRow(node.querySelector('.tree-row'));
                 }
-                
+
                 function expand() {
                     currentDepth++;
                     updateExpansion();
@@ -821,7 +819,7 @@ export class JsonTreeWebview {
                         saveState();
                     }
                 }
-                
+
                 function saveState() {
                     vscode.postMessage({ command: 'saveState', expansionDepth: currentDepth });
                 }
@@ -847,7 +845,7 @@ export class JsonTreeWebview {
                     clearHighlights();
                     searchMatches = [];
                     currentMatchIndex = -1;
-                    
+
                     if (!query) {
                         updateSearchUI();
                         return;
@@ -881,39 +879,39 @@ export class JsonTreeWebview {
                     const text = domNode.textContent;
                     const lowerText = text.toLowerCase();
                     let lastIndex = 0;
-                    
+
                     // Allow multiple matches in same string
                     const fragments = [];
                     let matchIndex = lowerText.indexOf(query, lastIndex);
-                    
-                    if (matchIndex === -1) return; 
+
+                    if (matchIndex === -1) return;
 
                     // We need to rebuild innerHTML
                     domNode.innerHTML = '';
-                    
+
                     while (matchIndex !== -1) {
                          const before = text.substring(lastIndex, matchIndex);
                          const match = text.substring(matchIndex, matchIndex + query.length);
-                         
+
                          domNode.appendChild(document.createTextNode(before));
-                         
+
                          const span = document.createElement('span');
                          span.className = 'highlight';
                          span.textContent = match;
                          domNode.appendChild(span);
                          searchMatches.push(span);
-                         
+
                          lastIndex = matchIndex + query.length;
                          matchIndex = lowerText.indexOf(query, lastIndex);
                     }
-                    
+
                     const after = text.substring(lastIndex);
                     domNode.appendChild(document.createTextNode(after));
                 }
 
                 function jumpToMatch(index) {
                     if (index < 0 || index >= searchMatches.length) return;
-                    
+
                     if (currentMatchIndex >= 0 && searchMatches[currentMatchIndex]) {
                         searchMatches[currentMatchIndex].classList.remove('current-match');
                     }
@@ -921,7 +919,7 @@ export class JsonTreeWebview {
                     currentMatchIndex = index;
                     const match = searchMatches[currentMatchIndex];
                     match.classList.add('current-match');
-                    
+
                     // Ensure visibility only when navigating
                     ensureVisible(match);
 
@@ -929,10 +927,10 @@ export class JsonTreeWebview {
                     setTimeout(() => {
                         match.scrollIntoView({ block: 'center', behavior: 'auto' });
                     }, 50);
-                    
+
                     const row = match.closest('.tree-row');
                     if (row) focusRow(row);
-                    
+
                     updateSearchUI();
                 }
 
@@ -965,7 +963,7 @@ export class JsonTreeWebview {
                         btnNext.disabled = true;
                     }
                 }
-                
+
                 searchInput.addEventListener('input', () => performSearch());
                 searchInput.addEventListener('keydown', (e) => {
                     if (e.key === 'Enter') {
@@ -973,11 +971,11 @@ export class JsonTreeWebview {
                         // Jump to next match (or first if none selected)
                         let nextIndex = currentMatchIndex + 1;
                         if (e.shiftKey) nextIndex = currentMatchIndex - 1;
-                        
+
                         // Wrap
                         if (nextIndex >= searchMatches.length) nextIndex = 0;
                         if (nextIndex < 0) nextIndex = searchMatches.length - 1;
-                        
+
                         jumpToMatch(nextIndex);
                     }
                 });
@@ -1038,9 +1036,9 @@ export class JsonTreeWebview {
                         searchInput.focus();
                     }
                 });
-                
+
                 function getNextVisibleRow(currentRow) {
-                     const allRows = Array.from(document.querySelectorAll('.tree-row')); 
+                     const allRows = Array.from(document.querySelectorAll('.tree-row'));
                      let idx = allRows.indexOf(currentRow);
                      for (let i = idx + 1; i < allRows.length; i++) {
                          if (isVisible(allRows[i])) return allRows[i];
@@ -1058,12 +1056,12 @@ export class JsonTreeWebview {
                 }
 
                 function isVisible(el) {
-                    return el.offsetParent !== null; 
+                    return el.offsetParent !== null;
                 }
 
                 const btnCollapseEl = document.getElementById('btn-collapse');
                 if (btnCollapseEl) btnCollapseEl.addEventListener('click', collapse);
-                
+
                 const btnExpandEl = document.getElementById('btn-expand');
                 if (btnExpandEl) btnExpandEl.addEventListener('click', expand);
 
@@ -1077,11 +1075,11 @@ export class JsonTreeWebview {
                         btnReveal.style.display = 'none';
                     }
                 }
-                
+
                 btnReveal.addEventListener('click', () => {
                    if (sourceUri && sourceLine >= 0) {
                        vscode.postMessage({ command: 'reveal', uri: sourceUri, line: sourceLine });
-                   } 
+                   }
                 });
 
                 window.addEventListener('message', event => {
@@ -1096,13 +1094,13 @@ export class JsonTreeWebview {
                              currentDepth = message.expansionDepth;
                              if (depthDisplay) depthDisplay.textContent = 'Depth ' + currentDepth;
                         }
-                        
+
                         // Reset search on update
                         if (searchInput) {
                             searchInput.value = '';
-                            performSearch(); 
+                            performSearch();
                         }
-                        
+
                         // Always switch to Tree View on new content
                         isTreeView = true;
                         updateView();

--- a/src/views/LogBookmarkWebviewProvider.ts
+++ b/src/views/LogBookmarkWebviewProvider.ts
@@ -488,7 +488,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
                         border-bottom: 1px solid var(--vscode-panel-border);
                         overflow: hidden;
                     }
-                    
+
                     .file-nav-bar {
                         display: flex;
                         align-items: center;
@@ -588,7 +588,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
                         font-weight: 700;
                     }
                     /* Ensure icons inherit color in active state */
-                    .file-section.active-file .action-btn, 
+                    .file-section.active-file .action-btn,
                     .file-section.active-file .nav-btn,
                     .file-section.active-file .fold-toggle {
                         color: var(--vscode-list-activeSelectionForeground);
@@ -638,7 +638,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
                         color: var(--vscode-breadcrumb-foreground);
                         padding: 1px 4px;
                         border-radius: 4px;
-                        
+
                         /* Layout & Overflow */
                         display: inline-block;
                         white-space: nowrap;
@@ -709,7 +709,6 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
                         opacity: 1;
                         background-color: var(--vscode-editor-selectionBackground);
                     }
-
 
 
                     .content {
@@ -856,7 +855,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
 
                     // Restore ID map for jumps
                     const itemsMap = ${JSON.stringify(itemsMap)};
-                    
+
                     // State Management for scroll position
                     let state = vscode.getState() || {};
 
@@ -894,7 +893,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
                         // 1. Remove old active classes
                         const activeFiles = document.querySelectorAll('.file-section.active-file');
                         activeFiles.forEach(el => el.classList.remove('active-file'));
-                        
+
                         const activeBtns = document.querySelectorAll('.file-nav-btn.active');
                         activeBtns.forEach(el => el.classList.remove('active'));
 
@@ -908,7 +907,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
 
                             const btn = document.querySelector('.file-nav-btn[data-uri="' + uriStr + '"]');
                             if (btn) btn.classList.add('active');
-                            
+
                             // 3. Smart Scroll
                             scrollToUri(uriStr);
                         }
@@ -918,7 +917,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
                     function focusFileScroll(uriStr) {
                         // Instant Scroll first
                         scrollToUri(uriStr);
-                        
+
                         // Focus in editor
                         vscode.postMessage({ type: 'focusFile', uriString: uriStr });
                     }
@@ -984,7 +983,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
                     function clearAll() {
                         vscode.postMessage({ type: 'clearAll' });
                     }
-                    
+
                      function toggleWordWrap() {
                         vscode.postMessage({ type: 'toggleWordWrap' });
                     }
@@ -1018,21 +1017,21 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
                     window.addEventListener('load', () => {
                         const activeEl = document.querySelector('.file-section.active-file');
                         if (activeEl) {
-                             // Smart scroll on load? 
+                             // Smart scroll on load?
                              // Wait for layout
                             setTimeout(() => {
                                 // Get Active URI from active element ID? ID="section-..."
                                 const id = activeEl.id;
                                 if (id && id.startsWith('section-')) {
                                     const uriStr = id.substring(8);
-                                    
+
                                      // Check visibility first
                                     const rect = activeEl.getBoundingClientRect();
                                     const isVisible = (
                                         rect.top >= 0 &&
                                         rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)
                                     );
-                                    
+
                                     if (!isVisible) {
                                          // Reuse logic
                                          let scrolled = false;
@@ -1043,7 +1042,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
                                                  scrolled = true;
                                              }
                                          }
-                                         
+
                                          if (!scrolled) {
                                               const firstLine = activeEl.querySelector('.log-line');
                                              if (firstLine) {
@@ -1056,7 +1055,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
                                 }
                             }, 100);
                         }
-                        
+
                         // Also scroll Active Button into view in the nav bar
                          const activeBtn = document.querySelector('.file-nav-btn.active');
                         if (activeBtn) {

--- a/src/views/QuickAccessProvider.ts
+++ b/src/views/QuickAccessProvider.ts
@@ -91,7 +91,7 @@ export class QuickAccessProvider implements vscode.TreeDataProvider<vscode.TreeI
 
     public toggleFileSizeUnit(): void {
         const size = this.getFileSize();
-        // If undefined (error/no file), just toggle blindly or do nothing? 
+        // If undefined (error/no file), just toggle blindly or do nothing?
         // If we can't determine size, we can't check for 0. Let's assume size is 0 if undefined.
         const safeSize = size ?? 0;
 
@@ -159,7 +159,7 @@ export class QuickAccessProvider implements vscode.TreeDataProvider<vscode.TreeI
         // Add a visual indicator for state beyond just text
         // We could use checkmark icon overlay, but for now Description + ContextValue is good.
         // Or we could change the icon color via ThemeColor if VS Code API supported it easily on TreeItems.
-        // Let's stick to standard icons but maybe change the icon itself if off? 
+        // Let's stick to standard icons but maybe change the icon itself if off?
         // User requested "buttons", so keeping the semantic icon is better.
 
         item.command = {


### PR DESCRIPTION
- Remove trailing whitespace across 11 source files (118 occurrences)
- Reduce consecutive blank lines (3+) to max 2 across 8 files
- Remove dead code: unused formatOutput(), checkMatch(), and duplicate ensureFilterMigration() in FilterManager
- Clean up design memo comments in FilterManager, LogBookmarkService, RegexUtils, and constants
- Remove placeholder comments in constants.ts
- Fix contextLine comment in Filter.ts (0,1,3,5,10 -> 0,3,5,9)
- Optimize LogBookmarkService.updateDecorations() to use _bookmarks directly instead of going through getBookmarks()