### PR TITLE
ci: add write permissions for release job

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   package:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Add contents: write permission to the package job in the GitHub Actions workflow. This is required to allow the softprops/action-gh-release action to create a release. Fixes the 403 Forbidden error during release creation.