### PR TITLE
refactor: address code review feedback and improve type safety

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -340,7 +340,6 @@ export const Constants = {
             CopiedItemsSingleLine: 'Copied {0} items to clipboard (single line).',
             CopiedItemsTags: 'Copied {0} items as tags to clipboard.',
             NoEnabledItems: 'No enabled items to copy (excluded filters ignored).',
-            NoEnabledItemsToCopy: 'No enabled items to copy (excluded filters ignored).',
             ProfileDeleted: 'Profile \'{0}\' deleted.',
             ProfileCreated: 'Profile \'{0}\' created and activated.',
             ProfileDuplicated: 'Profile duplicated as \'{0}\'.',
@@ -354,6 +353,7 @@ export const Constants = {
             NoSourceMapping: 'No source mapping found for this line.',
             FallbackToOpen: 'Failed to open text document (likely too large), falling back to vscode.open: {0}',
             AllBookmarksCopied: 'All bookmarks copied to clipboard.',
+            RemovedBookmarks: 'Removed {0} bookmarks matching selection \'{1}\'.',
 
         },
         Warn: {
@@ -397,6 +397,8 @@ export const Constants = {
             ImportFailed: 'Failed to import filters: {0}',
             ReadFilterFileFailed: 'Failed to read filter file: {0}',
             JumpToSourceFailed: 'Failed to jump to source: {0}',
+            FileTooLarge: 'Cannot {0}: File is too large (>50MB). Please reduce file size or use a different viewer.',
+            FailedToOpenBookmarks: 'Failed to open all bookmarks: {0}',
 
             ImportInvalidFormat: 'Invalid filter data format: expected an object with a "groups" array.',
             InvalidFilterPattern: 'Invalid filter pattern: "{0}"',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,8 +55,8 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	// Sync expansion state
-	const isGroup = (item: any): item is import('./models/Filter').FilterGroup => {
-		return item && typeof item === 'object' && Array.isArray((item as import('./models/Filter').FilterGroup).filters);
+	const isGroup = (item: unknown): item is import('./models/Filter').FilterGroup => {
+		return typeof item === 'object' && item !== null && Array.isArray((item as import('./models/Filter').FilterGroup).filters);
 	};
 
 	const setupExpansionSync = (view: vscode.TreeView<any>) => {

--- a/src/models/AdbModels.ts
+++ b/src/models/AdbModels.ts
@@ -75,7 +75,7 @@ export interface ControlDeviceActionItem {
     type: 'controlDeviceAction';
     actionType: ControlDeviceActionType;
     device: AdbDevice;
-    meta?: any;
+    meta?: Record<string, string>;
 }
 
 export interface MessageItem {

--- a/src/services/CommandManager.ts
+++ b/src/services/CommandManager.ts
@@ -640,7 +640,7 @@ export class CommandManager {
                     await vscode.env.clipboard.writeText(text);
                     vscode.window.showInformationMessage(Constants.Messages.Info.CopiedItemsSingleLine.replace('{0}', enabledFilters.length.toString()));
                 } else {
-                    vscode.window.showInformationMessage(Constants.Messages.Info.NoEnabledItemsToCopy);
+                    vscode.window.showInformationMessage(Constants.Messages.Info.NoEnabledItems);
                 }
             }
         }));
@@ -653,7 +653,7 @@ export class CommandManager {
                     await vscode.env.clipboard.writeText(text);
                     vscode.window.showInformationMessage(Constants.Messages.Info.CopiedItemsTags.replace('{0}', enabledFilters.length.toString()));
                 } else {
-                    vscode.window.showInformationMessage(Constants.Messages.Info.NoEnabledItemsToCopy);
+                    vscode.window.showInformationMessage(Constants.Messages.Info.NoEnabledItems);
                 }
             }
         }));

--- a/src/services/FilterManager.ts
+++ b/src/services/FilterManager.ts
@@ -717,9 +717,10 @@ export class FilterManager implements vscode.Disposable {
             } else {
                 throw new Error(Constants.Messages.Error.ImportInvalidFormat);
             }
-        } catch (e: any) {
-            this.logger.error(`Import failed: ${e.message}`);
-            return { count: 0, error: e.message };
+        } catch (e: unknown) {
+            const errorMessage = e instanceof Error ? e.message : String(e);
+            this.logger.error(`Import failed: ${errorMessage}`);
+            return { count: 0, error: errorMessage };
         }
     }
 

--- a/src/services/LogBookmarkCommandManager.ts
+++ b/src/services/LogBookmarkCommandManager.ts
@@ -93,7 +93,7 @@ export class LogBookmarkCommandManager {
                 editBuilder.replace(fullRange, allLines.join('\n'));
             });
         } catch (e) {
-            vscode.window.showErrorMessage(`Failed to open all bookmarks: ${e}`);
+            vscode.window.showErrorMessage(Constants.Messages.Error.FailedToOpenBookmarks.replace('{0}', String(e)));
         }
     }
 
@@ -204,7 +204,7 @@ export class LogBookmarkCommandManager {
                     removedCount++;
                 }
             }
-            vscode.window.showInformationMessage(`Removed ${removedCount} bookmarks matching selection '${selectedText}'.`);
+            vscode.window.showInformationMessage(Constants.Messages.Info.RemovedBookmarks.replace('{0}', removedCount.toString()).replace('{1}', selectedText));
         } else {
             this.processBookmarkMatches(editor, matchedLines, selectedText, MAX_MATCHES);
         }

--- a/src/services/LogProcessor.ts
+++ b/src/services/LogProcessor.ts
@@ -167,7 +167,7 @@ export class LogProcessor {
                     const adjustedMapping = lineMapping.map(l => l - 1);
                     resolve({ outputPath, processed, matched, lineMapping: adjustedMapping });
 
-                } catch (e: any) {
+                } catch (e: unknown) {
                     reject(e);
                 }
             })();

--- a/src/utils/EditorUtils.ts
+++ b/src/utils/EditorUtils.ts
@@ -26,7 +26,7 @@ export class EditorUtils {
                     const sizeMB = (size || 0) / (1024 * 1024);
 
                     if (sizeMB > 50) {
-                        vscode.window.showErrorMessage(`Cannot ${operationName}: File is too large (>50MB). Please reduce file size or use a different viewer.`);
+                        vscode.window.showErrorMessage(Constants.Messages.Error.FileTooLarge.replace('{0}', operationName));
                         return undefined;
                     }
                 }
@@ -52,7 +52,7 @@ export class EditorUtils {
      * @param onError Optional callback to handle errors
      * @returns The size in bytes, or undefined if it cannot be determined
      */
-    public static getFileSize(uri: vscode.Uri, onError?: (error: any) => void): number | undefined {
+    public static getFileSize(uri: vscode.Uri, onError?: (error: unknown) => void): number | undefined {
         try {
             if (uri.scheme === 'file') {
                 if (fs.existsSync(uri.fsPath)) {

--- a/src/views/AdbDeviceTreeProvider.ts
+++ b/src/views/AdbDeviceTreeProvider.ts
@@ -201,7 +201,7 @@ export class AdbDeviceTreeProvider implements vscode.TreeDataProvider<AdbTreeIte
 
                 return item;
             } else if (element.actionType === 'showTouches') {
-                const enabled = element.meta?.enabled === true;
+                const enabled = element.meta?.enabled === 'true';
                 const label = enabled ? 'Show Touches: On' : 'Show Touches: Off';
                 const item = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.None);
                 item.contextValue = enabled ? 'controlDeviceAction_showTouches_on' : 'controlDeviceAction_showTouches_off';
@@ -275,7 +275,7 @@ export class AdbDeviceTreeProvider implements vscode.TreeDataProvider<AdbTreeIte
                 return [
                     { type: 'controlDeviceAction', actionType: 'screenshot', device: element.device } as ControlDeviceActionItem,
                     { type: 'controlDeviceAction', actionType: 'screenRecord', device: element.device } as ControlDeviceActionItem,
-                    { type: 'controlDeviceAction', actionType: 'showTouches', device: element.device, meta: { enabled: showTouchesState } } as ControlDeviceActionItem
+                    { type: 'controlDeviceAction', actionType: 'showTouches', device: element.device, meta: { enabled: String(showTouchesState) } } as ControlDeviceActionItem
                 ];
             })();
         } else if (this.isSessionGroup(element)) {


### PR DESCRIPTION
Externalize remaining hardcoded strings to constants for better maintainability.
Consolidate duplicate 'NoEnabledItems' constant.
Improve type safety by replacing 'any' with 'unknown' or specific types (e.g., Record<string, string>) in AdbModels, FilterManager, and LogProcessor.
Strictly type check the 'isGroup' guard in extension.ts.