### PR TITLE
test: expand regression suite and add android log case

### DIFF
--- a/src/test/resources/expected_filtered.log
+++ b/src/test/resources/expected_filtered.log
@@ -1,0 +1,2 @@
+2023-10-27 10:00:02.000 ERROR [DB] Connection failed
+2023-10-27 10:00:03.000 ERROR [DB] Connection failed again

--- a/src/test/resources/sample.log
+++ b/src/test/resources/sample.log
@@ -1,0 +1,7 @@
+2023-10-27 10:00:00.000 INFO  [Main] Application started
+2023-10-27 10:00:01.000 DEBUG [Network] Connecting to server...
+2023-10-27 10:00:01.500 INFO  [Network] Connected
+2023-10-27 10:00:02.000 ERROR [DB] Connection failed
+2023-10-27 10:00:02.100 INFO  [DB] Retrying connection...
+2023-10-27 10:00:03.000 ERROR [DB] Connection failed again
+2023-10-27 10:00:04.000 INFO  [Main] Shutting down

--- a/src/test/resources/test_group_android.json
+++ b/src/test/resources/test_group_android.json
@@ -1,0 +1,40 @@
+{
+    "version": "1.5.4-dev.20260202055315",
+    "groups": [
+        {
+            "name": "tmp",
+            "filters": [
+                {
+                    "keyword": "Access denied",
+                    "type": "include",
+                    "isEnabled": true,
+                    "isRegex": false,
+                    "color": "color13",
+                    "contextLine": 0
+                },
+                {
+                    "keyword": "MainActivity",
+                    "type": "exclude",
+                    "isEnabled": true,
+                    "isRegex": false,
+                    "color": "color13",
+                    "contextLine": 0,
+                    "excludeStyle": "hidden"
+                },
+                {
+                    "keyword": "ime()",
+                    "type": "include",
+                    "isEnabled": true,
+                    "isRegex": false,
+                    "color": "color05",
+                    "contextLine": 3,
+                    "highlightMode": 1,
+                    "caseSensitive": true
+                }
+            ],
+            "isEnabled": true,
+            "isRegex": false,
+            "isExpanded": true
+        }
+    ]
+}

--- a/src/test/resources/test_log_android.log
+++ b/src/test/resources/test_log_android.log
@@ -1,0 +1,209 @@
+--------- beginning of system
+02-04 12:16:21.138  9122  9122 D Activity: onKeyUp(KEYCODE_BACK) isTracking()=true isCanceled()=true hasCallback=true
+--------- beginning of main
+02-04 13:00:06.554  9122  9122 I Choreographer: Skipped 71087 frames!  The application may be doing too much work on its main thread.
+02-04 13:00:06.560  9122 17326 I CameraManagerGlobal: Camera 4 facing CAMERA_FACING_FRONT state now CAMERA_STATE_OPENING for client client.pid<1709> API Level 2 User Id 0Device Id 0
+02-04 13:00:06.560  9122 17326 I CameraManagerGlobal: Camera 4 facing CAMERA_FACING_FRONT state now CAMERA_STATE_OPEN for client client.pid<1709> API Level 2 User Id 0Device Id 0
+02-04 13:00:06.560  9122 17326 I CameraManagerGlobal: Camera 4 facing CAMERA_FACING_FRONT state now CAMERA_STATE_ACTIVE for client client.pid<1709> API Level 2 User Id 0Device Id 0
+02-04 13:00:06.560  9122 17326 I CameraManagerGlobal: Camera 4 facing CAMERA_FACING_FRONT state now CAMERA_STATE_IDLE for client client.pid<1709> API Level 2 User Id 0Device Id 0
+02-04 13:00:06.560  9122 17326 I CameraManagerGlobal: Camera 4 facing CAMERA_FACING_FRONT state now CAMERA_STATE_CLOSED for client client.pid<1709> API Level 2 User Id 0Device Id 0
+02-04 13:00:06.573  9122 22124 D Choreographer: BBA2 receive callback when in bg : 4
+02-04 13:00:06.626  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.628  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.628  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.628  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.628  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.628  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.628  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.628  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.628  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.631  9122  9122 I VRI[MainActivity]@5d8296d: handleAppVisibility mAppVisible = false visible = true
+02-04 13:00:06.643  9122  9122 W BillingClient: Billing service disconnected.
+02-04 13:00:06.660  9122  9122 W BillingClient: Billing service disconnected.
+02-04 13:00:06.660  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.672  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.673  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.673  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.673  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:00:06.675  9122  9122 I VRI[MainActivity]@5d8296d: stopped(false) old = true
+02-04 13:00:06.675  9122  9122 D VRI[MainActivity]@5d8296d: WindowStopped on com.nullable.slrclub/com.nullable.slrclub.MainActivity set to false
+02-04 13:00:06.675  9122  9122 D ViewRootImpl: Skipping stats log for color mode
+02-04 13:00:06.693  9122  9156 D SessionLifecycleClient: Sending lifecycle 1 to service
+02-04 13:00:06.694  9122  9285 D SessionLifecycleService: Activity foregrounding at 229911158.
+02-04 13:00:06.717  9122  9122 W libc    : Access denied finding property "vendor.display.enable_optimal_refresh_rate"
+02-04 13:00:06.717  9122  9122 I BufferQueueProducer: [](id:23a200000002,api:0,p:-1,c:9122) setDequeueTimeout:2077252342
+02-04 13:00:06.718  9122  9122 I BLASTBufferQueue_Java: new BLASTBufferQueue, mName= VRI[MainActivity]@5d8296d mNativeObject= 0xb4000078e19fb000 caller= android.view.ViewRootImpl.updateBlastSurfaceIfNeeded:3585 android.view.ViewRootImpl.relayoutWindow:11685 android.view.ViewRootImpl.performTraversals:4804 android.view.ViewRootImpl.doTraversal:3924 android.view.ViewRootImpl$TraversalRunnable.run:12903 android.view.Choreographer$CallbackRecord.run:1901 android.view.Choreographer$CallbackRecord.run:1910 android.view.Choreographer.doCallbacks:1367 android.view.Choreographer.doFrame:1292 android.view.Choreographer$FrameDisplayEventReceiver.run:1870 
+02-04 13:00:06.718  9122  9122 I BLASTBufferQueue_Java: update, w= 1080 h= 2340 mName = VRI[MainActivity]@5d8296d mNativeObject= 0xb4000078e19fb000 sc.mNativeObject= 0xb4000077844cba00 format= -1 caller= android.view.ViewRootImpl.updateBlastSurfaceIfNeeded:3590 android.view.ViewRootImpl.relayoutWindow:11685 android.view.ViewRootImpl.performTraversals:4804 android.view.ViewRootImpl.doTraversal:3924 android.view.ViewRootImpl$TraversalRunnable.run:12903 android.view.Choreographer$CallbackRecord.run:1901 
+02-04 13:00:06.719  9122  9122 W libc    : Access denied finding property "vendor.display.enable_optimal_refresh_rate"
+02-04 13:00:06.719  9122  9122 I VRI[MainActivity]@5d8296d: Relayout returned: old=(0,0,1080,2340) new=(0,0,1080,2340) relayoutAsync=false req=(1080,2340)0 dur=8 res=0x3 s={true 0xb400007793cb8800} ch=true seqId=0
+02-04 13:00:06.719  9122  9122 D VRI[MainActivity]@5d8296d: mThreadedRenderer.initialize() mSurface={isValid=true 0xb400007793cb8800} hwInitialized=true
+02-04 13:00:06.721  9122  9122 D VRI[MainActivity]@5d8296d: reportNextDraw android.view.ViewRootImpl.performTraversals:5443 android.view.ViewRootImpl.doTraversal:3924 android.view.ViewRootImpl$TraversalRunnable.run:12903 android.view.Choreographer$CallbackRecord.run:1901 android.view.Choreographer$CallbackRecord.run:1910 
+02-04 13:00:06.721  9122  9122 D VRI[MainActivity]@5d8296d: Setup new sync=wmsSync-VRI[MainActivity]@5d8296d#4
+02-04 13:00:06.721  9122  9122 I VRI[MainActivity]@5d8296d: Creating new active sync group VRI[MainActivity]@5d8296d#5
+02-04 13:00:06.722  9122  9122 D VRI[MainActivity]@5d8296d: Start draw after previous draw not visible
+02-04 13:00:06.722  9122  9122 D VRI[MainActivity]@5d8296d: registerCallbacksForSync syncBuffer=false
+02-04 13:00:06.763  9122  9184 D VRI[MainActivity]@5d8296d: Received frameDrawingCallback syncResult=0 frameNum=1.
+02-04 13:00:06.763  9122  9184 I VRI[MainActivity]@5d8296d: mWNT: t=0xb4000078f07f4f80 mBlastBufferQueue=0xb4000078e19fb000 fn= 1 HdrRenderState mRenderHdrSdrRatio=1.0 caller= android.view.ViewRootImpl$12.onFrameDraw:15441 android.view.ThreadedRenderer$1.onFrameDraw:718 <bottom of call stack> 
+02-04 13:00:06.763  9122  9184 I VRI[MainActivity]@5d8296d: Setting up sync and frameCommitCallback
+02-04 13:00:06.766  9122  9170 I BLASTBufferQueue: [VRI[MainActivity]@5d8296d#2](f:0,a:0,s:0) onFrameAvailable the first frame is available
+02-04 13:00:06.767  9122  9170 I SurfaceComposerClient: apply transaction with the first frame. layerId: 23544, bufferData(ID: 39178691674130, frameNumber: 1)
+02-04 13:00:06.770  9122  9170 I VRI[MainActivity]@5d8296d: Received frameCommittedCallback lastAttemptedDrawFrameNum=1 didProduceBuffer=true
+02-04 13:00:06.770  9122  9122 D VRI[MainActivity]@5d8296d: reportDrawFinished seqId=0
+02-04 13:00:06.802  9122  9122 I InsetsSourceConsumer: applyRequestedVisibilityToControl: visible=true, type=navigationBars, host=com.nullable.slrclub/com.nullable.slrclub.MainActivity
+02-04 13:00:06.803  9122  9122 I InsetsSourceConsumer: applyRequestedVisibilityToControl: visible=true, type=statusBars, host=com.nullable.slrclub/com.nullable.slrclub.MainActivity
+02-04 13:00:06.804  9122  9122 D VRI[MainActivity]@5d8296d: mThreadedRenderer.initializeIfNeeded()#2 mSurface={isValid=true 0xb400007793cb8800}
+02-04 13:00:06.808  9122  9122 D InputMethodManagerUtils: startInputInner - Id : 0
+02-04 13:00:06.808  9122  9122 I InputMethodManager: startInputInner - IInputMethodManagerGlobalInvoker.startInputOrWindowGainedFocus
+02-04 13:00:06.813  9122  9122 I InputMethodManager: handleMessage: setImeVisibility visible=false
+02-04 13:00:06.813  9122  9122 D InsetsController: hide(ime(), fromIme=false)
+02-04 13:00:06.813  9122  9122 I ImeTracker: com.nullable.slrclub:e319aa6b: onCancelled at PHASE_CLIENT_ALREADY_HIDDEN
+02-04 13:00:06.829  9122 22124 D InputTransport: Input channel constructed: 'ClientS', fd=178
+02-04 13:00:18.432  9122  9122 I VRI[MainActivity]@5d8296d: ViewPostIme pointer 0
+02-04 13:00:18.442  9122  9122 I VRI[MainActivity]@5d8296d: call setFrameRateCategory for touch hint category=high hint, reason=touch, vri=VRI[MainActivity]@5d8296d
+02-04 13:00:18.794  9122  9122 I VRI[MainActivity]@5d8296d: ViewPostIme pointer 1
+02-04 13:00:19.322  9122  9122 I VRI[MainActivity]@5d8296d: ViewPostIme pointer 0
+02-04 13:00:19.361  9122  9122 I VRI[MainActivity]@5d8296d: ViewPostIme pointer 1
+02-04 13:00:19.458  9122  9122 I AdFit3.19.5: Terminated AdFit Ad
+02-04 13:00:19.472  9122  9122 D ConnectivityManager: StackLog: [android.net.ConnectivityManager.unregisterNetworkCallback(ConnectivityManager.java:5571)] [WV.nm1.h(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:17)] [WV.ck.b(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:3)] [org.chromium.android_webview.AwContentsLifecycleNotifier.onLastWebViewDestroyed(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:19)] [J.N.VJ(Native Method)] [WV.ng.run(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:4)] [WV.gx.handleMessage(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:55)] [WV.ix.a(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:25)] [org.chromium.android_webview.AwContents.l(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:33)] [WV.xf.run(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:10)] [org.chromium.base.task.TaskRunnerImpl.runTask(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:31)]
+02-04 13:00:19.474  9122  9122 D ConnectivityManager: StackLog: [android.net.ConnectivityManager.unregisterNetworkCallback(ConnectivityManager.java:5571)] [WV.nm1.h(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:26)] [WV.ck.b(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:3)] [org.chromium.android_webview.AwContentsLifecycleNotifier.onLastWebViewDestroyed(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:19)] [J.N.VJ(Native Method)] [WV.ng.run(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:4)] [WV.gx.handleMessage(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:55)] [WV.ix.a(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:25)] [org.chromium.android_webview.AwContents.l(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:33)] [WV.xf.run(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:10)] [org.chromium.base.task.TaskRunnerImpl.runTask(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:31)]
+02-04 13:00:19.500  9122  9127 I ullable.slrclub: Background concurrent mark compact GC freed 63MB AllocSpace bytes, 74(1824KB) LOS objects, 66% free, 16MB/50MB, paused 956us,1.626ms total 134.288ms
+02-04 13:00:19.530  9122 10171 I Kumiho-Kumiho: getPackageName: com.nullable.slrclub
+02-04 13:00:19.530  9122 22183 I Kumiho-Kumiho: getPackageName: com.nullable.slrclub
+02-04 13:00:19.531  9122  9122 I AdFit3.19.5: Request Banner AD
+02-04 13:00:19.533  9122 30769 D AdvertisingIdClient: AdvertisingIdClient already created.
+02-04 13:00:19.533  9122 30769 D AdvertisingIdClient: AdvertisingIdClient is not bounded. Starting to bind it...
+02-04 13:00:19.545  9122 30769 D AdvertisingIdClient: AdvertisingIdClient is bounded
+02-04 13:00:19.547  9122 30769 I AdvertisingIdClient: shouldSendLog 619432210
+02-04 13:00:19.547  9122 30769 I AdvertisingIdClient: GetInfoInternal elapse 13ms
+02-04 13:00:19.547  9122 30769 I AdFit3.19.5: Get Advertising Id from Google Play services. [id = d7da3ac6-f2a9-45ef-9fdb-c1b10f0c1b03] [isLimitAdTrackingEnabled = false]
+02-04 13:00:19.558  9122  9122 I AdvertisingIdClient: getting error as 17: API: ClientTelemetry.API is not available on this device. Connection failed with: b{statusCode=API_DISABLED_FOR_CONNECTION, resolution=null, message=null}
+02-04 13:00:20.013  9122  9122 D ConnectivityManager: StackLog: [android.net.ConnectivityManager.sendRequestForNetwork(ConnectivityManager.java:4736)] [android.net.ConnectivityManager.registerDefaultNetworkCallbackForUid(ConnectivityManager.java:5461)] [android.net.ConnectivityManager.registerDefaultNetworkCallback(ConnectivityManager.java:5428)] [WV.mm1.e(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:37)] [WV.mm1.a(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:1)] [org.chromium.android_webview.AwContentsLifecycleNotifier.onFirstWebViewCreated(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:19)] [J.N.JJ(Native Method)] [org.chromium.android_webview.AwContents.<init>(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:628)] [com.android.webview.chromium.r.run(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:223)] [WV.u13.run(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:13)] [org.chromium.base.task.PostTask.d(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:18)] [WV.v13.a(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:18)] [com.android.webview.chromium.WebViewChromiumFactoryProvider.a(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:3)] [com.android.webview.chromium.WebViewChromium.init(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:273)] [android.webkit.WebView.<init>(WebView.java:447)] [android.webkit.WebView.<init>(WebView.java:367)] [android.webkit.WebView.<init>(WebView.java:349)] [android.webkit.WebView.<init>(WebView.java:336)] [android.webkit.WebView.<init>(WebView.java:326)] [com.kakao.adfit.a.r.<init>(SourceFile:1)] [com.kakao.adfit.b.a.a(SourceFile:2)] [com.kakao.adfit.ads.ba.BannerAdView.a(SourceFile:2)] [com.kakao.adfit.ads.ba.BannerAdView.access$createAdWebView(SourceFile:1)] [com.kakao.adfit.ads.ba.BannerAdView$b.a(SourceFile:3)] [com.kakao.adfit.ads.ba.d.b(SourceFile:6)] [com.kakao.adfit.ads.ba.d$j.invokeSuspend(SourceFile:529)] [tk.a.resumeWith(SourceFile:12)] [kotlinx.coroutines.DispatchedTask.run(SourceFile:129)]
+02-04 13:00:20.016  9122  9122 D ConnectivityManager: StackLog: [android.net.ConnectivityManager.sendRequestForNetwork(ConnectivityManager.java:4736)] [android.net.ConnectivityManager.sendRequestForNetwork(ConnectivityManager.java:4904)] [android.net.ConnectivityManager.registerNetworkCallback(ConnectivityManager.java:5321)] [WV.mm1.e(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:86)] [WV.mm1.a(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:1)] [org.chromium.android_webview.AwContentsLifecycleNotifier.onFirstWebViewCreated(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:19)] [J.N.JJ(Native Method)] [org.chromium.android_webview.AwContents.<init>(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:628)] [com.android.webview.chromium.r.run(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:223)] [WV.u13.run(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:13)] [org.chromium.base.task.PostTask.d(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:18)] [WV.v13.a(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:18)] [com.android.webview.chromium.WebViewChromiumFactoryProvider.a(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:3)] [com.android.webview.chromium.WebViewChromium.init(chromium-TrichromeWebViewGoogle6432.aab-stable-755910933:273)] [android.webkit.WebView.<init>(WebView.java:447)] [android.webkit.WebView.<init>(WebView.java:367)] [android.webkit.WebView.<init>(WebView.java:349)] [android.webkit.WebView.<init>(WebView.java:336)] [android.webkit.WebView.<init>(WebView.java:326)] [com.kakao.adfit.a.r.<init>(SourceFile:1)] [com.kakao.adfit.b.a.a(SourceFile:2)] [com.kakao.adfit.ads.ba.BannerAdView.a(SourceFile:2)] [com.kakao.adfit.ads.ba.BannerAdView.access$createAdWebView(SourceFile:1)] [com.kakao.adfit.ads.ba.BannerAdView$b.a(SourceFile:3)] [com.kakao.adfit.ads.ba.d.b(SourceFile:6)] [com.kakao.adfit.ads.ba.d$j.invokeSuspend(SourceFile:529)] [tk.a.resumeWith(SourceFile:12)] [kotlinx.coroutines.DispatchedTask.run(SourceFile:129)]
+02-04 13:00:20.415  9122 30773 I Kumiho-Kumiho: getPackageName: com.nullable.slrclub
+02-04 13:00:20.465  9122 30773 I Kumiho-Kumiho: getPackageName: com.nullable.slrclub
+02-04 13:00:20.469  9122 30725 I Kumiho-Kumiho: getPackageName: com.nullable.slrclub
+02-04 13:00:20.521  9122 10171 I Kumiho-Kumiho: getPackageName: com.nullable.slrclub
+02-04 13:00:20.521  9122 30714 I Kumiho-Kumiho: getPackageName: com.nullable.slrclub
+02-04 13:00:20.522  9122 30780 I Kumiho-Kumiho: getPackageName: com.nullable.slrclub
+02-04 13:00:20.527  9122 30772 I Kumiho-Kumiho: getPackageName: com.nullable.slrclub
+02-04 13:00:20.536  9122 30772 I Kumiho-Kumiho: getPackageName: com.nullable.slrclub
+02-04 13:00:22.365  9122  9122 I VRI[MainActivity]@5d8296d: call setFrameRateCategory for touch hint category=no preference, reason=boost timeout, vri=VRI[MainActivity]@5d8296d
+02-04 13:00:22.612  9122  9122 I VRI[MainActivity]@5d8296d: ViewPostIme pointer 0
+02-04 13:00:22.613  9122  9122 I VRI[MainActivity]@5d8296d: call setFrameRateCategory for touch hint category=high hint, reason=touch, vri=VRI[MainActivity]@5d8296d
+02-04 13:00:22.698  9122  9122 I VRI[MainActivity]@5d8296d: ViewPostIme pointer 1
+02-04 13:00:23.199  9122  9122 I AdFit3.19.5: Request Native AD
+02-04 13:00:24.724  9122  9122 I VRI[MainActivity]@5d8296d: ViewPostIme key 0
+02-04 13:00:24.724  9122  9122 D Activity: onKeyDown(KEYCODE_BACK), activity=com.nullable.slrclub.MainActivity@baaa8ab
+02-04 13:00:24.726  9122  9122 I VRI[MainActivity]@5d8296d: ViewPostIme key 1
+02-04 13:00:24.726  9122  9122 D Activity: onKeyUp(KEYCODE_BACK) isTracking()=true isCanceled()=true hasCallback=true
+02-04 13:00:25.471  9122  9122 I VRI[MainActivity]@5d8296d: ViewPostIme pointer 0
+02-04 13:00:25.718  9122  9122 I ImeFocusController: onPreWindowFocus: skipped hasWindowFocus=false mHasImeFocus=true
+02-04 13:00:25.718  9122  9122 I ImeFocusController: onPostWindowFocus: skipped hasWindowFocus=false mHasImeFocus=true
+02-04 13:00:26.475  9122  9156 D SessionLifecycleClient: Sending lifecycle 2 to service
+02-04 13:00:26.476  9122  9285 D SessionLifecycleService: Activity backgrounding at 229930940
+02-04 13:00:26.485  9122  9122 I VRI[MainActivity]@5d8296d: handleAppVisibility mAppVisible = true visible = false
+02-04 13:00:26.485  9122  9122 D VRI[MainActivity]@5d8296d: visibilityChanged oldVisibility=true newVisibility=false
+02-04 13:00:26.495  9122  9170 D HWUI    : CacheManager::trimMemory(20)
+02-04 13:00:26.502  9122  9122 I VRI[MainActivity]@5d8296d: Relayout returned: old=(0,0,1080,2340) new=(0,0,1080,2340) relayoutAsync=false req=(1080,2340)8 dur=5 res=0x2 s={false 0x0} ch=true seqId=0
+02-04 13:00:26.502  9122  9122 D VRI[MainActivity]@5d8296d: Not drawing due to not visible. Reason=!mAppVisible && !mForceDecorViewVisibility
+02-04 13:00:26.504  9122  9170 D HWUI    : CacheManager::trimMemory(20)
+02-04 13:00:26.508  9122  9122 W WindowOnBackDispatcher: sendCancelIfRunning: isInProgress=false callback=b.e0$g$a@11b1452
+02-04 13:00:26.515  9122  9122 I VRI[MainActivity]@5d8296d: stopped(true) old = false
+02-04 13:00:26.515  9122  9122 D VRI[MainActivity]@5d8296d: WindowStopped on com.nullable.slrclub/com.nullable.slrclub.MainActivity set to true
+02-04 13:00:26.515  9122  9170 D HWUI    : CacheManager::trimMemory(20)
+02-04 13:00:26.532  9122  9122 D InputTransport: Input channel destroyed: 'ClientS', fd=178
+02-04 13:00:26.539  9122  9122 D BBA2    : setIsFg isFg = false; delayValue 3999ms
+02-04 13:00:28.490  9122 30712 I FA      : Application backgrounded at: timestamp_millis: 1770177626488
+02-04 13:00:30.562  9122  9122 D Choreographer: CoreRune.SYSPERF_ACTIVE_APP_BBA_ENABLE : stop animation in background states
+02-04 13:00:44.659  9122  9161 I TRuntime.CctTransportBackend: Making request to: https://firebaselogging.googleapis.com/v0cc/log/batch?format=json_proto3
+02-04 13:00:44.660  9122  9122 W JobService: onNetworkChanged() not implemented in com.google.android.datatransport.runtime.scheduling.jobscheduling.JobInfoSchedulerService. Must override in a subclass.
+02-04 13:00:45.080  9122  9122 W JobService: onNetworkChanged() not implemented in com.google.android.datatransport.runtime.scheduling.jobscheduling.JobInfoSchedulerService. Must override in a subclass.
+02-04 13:00:45.344  9122  9161 I TRuntime.CctTransportBackend: Status Code: 200
+02-04 13:01:20.956  9122 30704 I CameraManagerGlobal: Camera 4 facing CAMERA_FACING_FRONT state now CAMERA_STATE_OPENING for client client.pid<1709> API Level 2 User Id 0Device Id 0
+02-04 13:01:21.094  9122 30704 I CameraManagerGlobal: Camera 4 facing CAMERA_FACING_FRONT state now CAMERA_STATE_OPEN for client client.pid<1709> API Level 2 User Id 0Device Id 0
+02-04 13:01:21.213  9122 30704 I CameraManagerGlobal: Camera 4 facing CAMERA_FACING_FRONT state now CAMERA_STATE_ACTIVE for client client.pid<1709> API Level 2 User Id 0Device Id 0
+02-04 13:01:22.886  9122 22124 I CameraManagerGlobal: Camera 4 facing CAMERA_FACING_FRONT state now CAMERA_STATE_IDLE for client client.pid<1709> API Level 2 User Id 0Device Id 0
+02-04 13:01:23.251  9122 22124 I CameraManagerGlobal: Camera 4 facing CAMERA_FACING_FRONT state now CAMERA_STATE_CLOSED for client client.pid<1709> API Level 2 User Id 0Device Id 0
+02-04 13:01:32.787  9122  9122 I VRI[MainActivity]@5d8296d: handleAppVisibility mAppVisible = false visible = true
+02-04 13:01:32.793  9122  9122 I VRI[MainActivity]@5d8296d: stopped(false) old = true
+02-04 13:01:32.793  9122  9122 D VRI[MainActivity]@5d8296d: WindowStopped on com.nullable.slrclub/com.nullable.slrclub.MainActivity set to false
+02-04 13:01:32.793  9122  9122 D ViewRootImpl: Skipping stats log for color mode
+02-04 13:01:32.794  9122  9122 D BBA2    : setIsFg isFg = true
+02-04 13:01:32.801  9122  9156 D SessionLifecycleClient: Sending lifecycle 1 to service
+02-04 13:01:32.801  9122  9285 D SessionLifecycleService: Activity foregrounding at 229997265.
+02-04 13:01:32.816  9122  9122 W libc    : Access denied finding property "vendor.display.enable_optimal_refresh_rate"
+02-04 13:01:32.816  9122  9122 I BufferQueueProducer: [](id:23a200000003,api:0,p:-1,c:9122) setDequeueTimeout:2077252342
+02-04 13:01:32.816  9122  9122 I BLASTBufferQueue_Java: new BLASTBufferQueue, mName= VRI[MainActivity]@5d8296d mNativeObject= 0xb4000078e19fb000 caller= android.view.ViewRootImpl.updateBlastSurfaceIfNeeded:3585 android.view.ViewRootImpl.relayoutWindow:11685 android.view.ViewRootImpl.performTraversals:4804 android.view.ViewRootImpl.doTraversal:3924 android.view.ViewRootImpl$TraversalRunnable.run:12903 android.view.Choreographer$CallbackRecord.run:1901 android.view.Choreographer$CallbackRecord.run:1910 android.view.Choreographer.doCallbacks:1367 android.view.Choreographer.doFrame:1292 android.view.Choreographer$FrameDisplayEventReceiver.run:1870 
+02-04 13:01:32.816  9122  9122 I BLASTBufferQueue_Java: update, w= 1080 h= 2340 mName = VRI[MainActivity]@5d8296d mNativeObject= 0xb4000078e19fb000 sc.mNativeObject= 0xb4000078f07dda00 format= -1 caller= android.view.ViewRootImpl.updateBlastSurfaceIfNeeded:3590 android.view.ViewRootImpl.relayoutWindow:11685 android.view.ViewRootImpl.performTraversals:4804 android.view.ViewRootImpl.doTraversal:3924 android.view.ViewRootImpl$TraversalRunnable.run:12903 android.view.Choreographer$CallbackRecord.run:1901 
+02-04 13:01:32.817  9122  9122 W libc    : Access denied finding property "vendor.display.enable_optimal_refresh_rate"
+02-04 13:01:32.817  9122  9122 I VRI[MainActivity]@5d8296d: Relayout returned: old=(0,0,1080,2340) new=(0,0,1080,2340) relayoutAsync=false req=(1080,2340)0 dur=9 res=0x3 s={true 0xb400007793a4aa00} ch=true seqId=0
+02-04 13:01:32.817  9122  9122 D VRI[MainActivity]@5d8296d: mThreadedRenderer.initialize() mSurface={isValid=true 0xb400007793a4aa00} hwInitialized=true
+02-04 13:01:32.817  9122  9122 D VRI[MainActivity]@5d8296d: reportNextDraw android.view.ViewRootImpl.performTraversals:5443 android.view.ViewRootImpl.doTraversal:3924 android.view.ViewRootImpl$TraversalRunnable.run:12903 android.view.Choreographer$CallbackRecord.run:1901 android.view.Choreographer$CallbackRecord.run:1910 
+02-04 13:01:32.817  9122  9122 D VRI[MainActivity]@5d8296d: Setup new sync=wmsSync-VRI[MainActivity]@5d8296d#6
+02-04 13:01:32.817  9122  9122 I VRI[MainActivity]@5d8296d: Creating new active sync group VRI[MainActivity]@5d8296d#7
+02-04 13:01:32.817  9122  9122 D VRI[MainActivity]@5d8296d: Start draw after previous draw not visible
+02-04 13:01:32.824  9122  9122 D VRI[MainActivity]@5d8296d: registerCallbacksForSync syncBuffer=false
+02-04 13:01:32.834  9122  9185 D VRI[MainActivity]@5d8296d: Received frameDrawingCallback syncResult=0 frameNum=1.
+02-04 13:01:32.834  9122  9185 I VRI[MainActivity]@5d8296d: mWNT: t=0xb4000078f07f3000 mBlastBufferQueue=0xb4000078e19fb000 fn= 1 HdrRenderState mRenderHdrSdrRatio=1.0 caller= android.view.ViewRootImpl$12.onFrameDraw:15441 android.view.ThreadedRenderer$1.onFrameDraw:718 <bottom of call stack> 
+02-04 13:01:32.834  9122  9185 I VRI[MainActivity]@5d8296d: Setting up sync and frameCommitCallback
+02-04 13:01:32.847  9122  9170 I BLASTBufferQueue: [VRI[MainActivity]@5d8296d#3](f:0,a:0,s:0) onFrameAvailable the first frame is available
+02-04 13:01:32.847  9122  9170 I SurfaceComposerClient: apply transaction with the first frame. layerId: 23593, bufferData(ID: 39178691674135, frameNumber: 1)
+02-04 13:01:32.848  9122  9170 I VRI[MainActivity]@5d8296d: Received frameCommittedCallback lastAttemptedDrawFrameNum=1 didProduceBuffer=true
+02-04 13:01:32.848  9122  9122 D VRI[MainActivity]@5d8296d: reportDrawFinished seqId=0
+02-04 13:01:32.852  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:01:32.853  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:01:32.853  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:01:32.853  9122  9122 I VRI[MainActivity]@5d8296d: onDisplayChanged oldDisplayState=2 newDisplayState=2
+02-04 13:01:32.854  9122  9122 I InsetsSourceConsumer: applyRequestedVisibilityToControl: visible=true, type=navigationBars, host=com.nullable.slrclub/com.nullable.slrclub.MainActivity
+02-04 13:01:32.854  9122  9122 I InsetsSourceConsumer: applyRequestedVisibilityToControl: visible=true, type=statusBars, host=com.nullable.slrclub/com.nullable.slrclub.MainActivity
+02-04 13:01:32.871  9122  9122 D VRI[MainActivity]@5d8296d: mThreadedRenderer.initializeIfNeeded()#2 mSurface={isValid=true 0xb400007793a4aa00}
+02-04 13:01:32.875  9122  9122 D InputMethodManagerUtils: startInputInner - Id : 0
+02-04 13:01:32.875  9122  9122 I InputMethodManager: startInputInner - IInputMethodManagerGlobalInvoker.startInputOrWindowGainedFocus
+02-04 13:01:32.879  9122  9122 I InputMethodManager: handleMessage: setImeVisibility visible=false
+02-04 13:01:32.879  9122  9122 D InsetsController: hide(ime(), fromIme=false)
+02-04 13:01:32.879  9122  9122 I ImeTracker: com.nullable.slrclub:cd722d6b: onCancelled at PHASE_CLIENT_ALREADY_HIDDEN
+02-04 13:01:32.883  9122 30704 D InputTransport: Input channel constructed: 'ClientS', fd=212
+02-04 13:01:34.379  9122  9122 I AdFit3.19.5: Request Banner AD
+02-04 13:01:34.382  9122 31512 D AdvertisingIdClient: AdvertisingIdClient already created.
+02-04 13:01:34.382  9122 31512 D AdvertisingIdClient: AdvertisingIdClient is not bounded. Starting to bind it...
+02-04 13:01:34.387  9122 31512 D AdvertisingIdClient: AdvertisingIdClient is bounded
+02-04 13:01:34.389  9122 31512 I AdvertisingIdClient: shouldSendLog 622197732
+02-04 13:01:34.390  9122 31512 I AdvertisingIdClient: GetInfoInternal elapse 7ms
+02-04 13:01:34.390  9122 31512 I AdFit3.19.5: Get Advertising Id from Google Play services. [id = d7da3ac6-f2a9-45ef-9fdb-c1b10f0c1b03] [isLimitAdTrackingEnabled = false]
+02-04 13:01:34.812  9122  9122 I VRI[MainActivity]@5d8296d: ViewPostIme pointer 0
+02-04 13:01:34.814  9122  9122 I VRI[MainActivity]@5d8296d: call setFrameRateCategory for touch hint category=high hint, reason=touch, vri=VRI[MainActivity]@5d8296d
+02-04 13:01:34.892  9122  9122 I ImeFocusController: onPreWindowFocus: skipped hasWindowFocus=false mHasImeFocus=true
+02-04 13:01:34.892  9122  9122 I ImeFocusController: onPostWindowFocus: skipped hasWindowFocus=false mHasImeFocus=true
+02-04 13:01:35.727  9122  9156 D SessionLifecycleClient: Sending lifecycle 2 to service
+02-04 13:01:35.727  9122  9285 D SessionLifecycleService: Activity backgrounding at 230000192
+02-04 13:01:35.730  9122  9122 I VRI[MainActivity]@5d8296d: handleAppVisibility mAppVisible = true visible = false
+02-04 13:01:35.730  9122  9122 D VRI[MainActivity]@5d8296d: visibilityChanged oldVisibility=true newVisibility=false
+02-04 13:01:35.746  9122  9170 D HWUI    : CacheManager::trimMemory(20)
+02-04 13:01:35.752  9122  9122 I VRI[MainActivity]@5d8296d: Relayout returned: old=(0,0,1080,2340) new=(0,0,1080,2340) relayoutAsync=false req=(1080,2340)8 dur=5 res=0x2 s={false 0x0} ch=true seqId=0
+02-04 13:01:35.752  9122  9122 D VRI[MainActivity]@5d8296d: Not drawing due to not visible. Reason=!mAppVisible && !mForceDecorViewVisibility
+02-04 13:01:35.754  9122  9122 W WindowOnBackDispatcher: sendCancelIfRunning: isInProgress=false callback=b.e0$g$a@11b1452
+02-04 13:01:35.755  9122  9122 I VRI[MainActivity]@5d8296d: stopped(true) old = false
+02-04 13:01:35.755  9122  9122 D VRI[MainActivity]@5d8296d: WindowStopped on com.nullable.slrclub/com.nullable.slrclub.MainActivity set to true
+02-04 13:01:35.755  9122  9170 D HWUI    : CacheManager::trimMemory(20)
+02-04 13:01:35.755  9122  9170 D HWUI    : CacheManager::trimMemory(20)
+02-04 13:01:35.772  9122  9122 D BBA2    : setIsFg isFg = false; delayValue 3999ms
+02-04 13:01:35.774  9122  9122 D InputTransport: Input channel destroyed: 'ClientS', fd=212
+02-04 13:01:37.768  9122 31508 I FA      : Application backgrounded at: timestamp_millis: 1770177695767
+02-04 13:01:39.786  9122  9122 D Choreographer: CoreRune.SYSPERF_ACTIVE_APP_BBA_ENABLE : stop animation in background states

--- a/src/test/resources/test_log_android_filtered.log
+++ b/src/test/resources/test_log_android_filtered.log
@@ -1,0 +1,18 @@
+02-04 13:00:06.717  9122  9122 W libc    : Access denied finding property "vendor.display.enable_optimal_refresh_rate"
+02-04 13:00:06.719  9122  9122 W libc    : Access denied finding property "vendor.display.enable_optimal_refresh_rate"
+02-04 13:00:06.808  9122  9122 D InputMethodManagerUtils: startInputInner - Id : 0
+02-04 13:00:06.808  9122  9122 I InputMethodManager: startInputInner - IInputMethodManagerGlobalInvoker.startInputOrWindowGainedFocus
+02-04 13:00:06.813  9122  9122 I InputMethodManager: handleMessage: setImeVisibility visible=false
+02-04 13:00:06.813  9122  9122 D InsetsController: hide(ime(), fromIme=false)
+02-04 13:00:06.813  9122  9122 I ImeTracker: com.nullable.slrclub:e319aa6b: onCancelled at PHASE_CLIENT_ALREADY_HIDDEN
+02-04 13:00:06.829  9122 22124 D InputTransport: Input channel constructed: 'ClientS', fd=178
+02-04 13:00:18.432  9122  9122 I VRI[MainActivity]@5d8296d: ViewPostIme pointer 0
+02-04 13:01:32.816  9122  9122 W libc    : Access denied finding property "vendor.display.enable_optimal_refresh_rate"
+02-04 13:01:32.817  9122  9122 W libc    : Access denied finding property "vendor.display.enable_optimal_refresh_rate"
+02-04 13:01:32.875  9122  9122 D InputMethodManagerUtils: startInputInner - Id : 0
+02-04 13:01:32.875  9122  9122 I InputMethodManager: startInputInner - IInputMethodManagerGlobalInvoker.startInputOrWindowGainedFocus
+02-04 13:01:32.879  9122  9122 I InputMethodManager: handleMessage: setImeVisibility visible=false
+02-04 13:01:32.879  9122  9122 D InsetsController: hide(ime(), fromIme=false)
+02-04 13:01:32.879  9122  9122 I ImeTracker: com.nullable.slrclub:cd722d6b: onCancelled at PHASE_CLIENT_ALREADY_HIDDEN
+02-04 13:01:32.883  9122 30704 D InputTransport: Input channel constructed: 'ClientS', fd=212
+02-04 13:01:34.379  9122  9122 I AdFit3.19.5: Request Banner AD

--- a/src/test/services/FilterManager.test.ts
+++ b/src/test/services/FilterManager.test.ts
@@ -1,0 +1,229 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { FilterManager } from '../../services/FilterManager';
+import { FilterGroup, FilterItem, FilterType } from '../../models/Filter';
+import { Constants } from '../../constants';
+
+// Mock Memento for GlobalState
+class MockMemento implements vscode.Memento {
+    private storage = new Map<string, any>();
+
+    get<T>(key: string): T | undefined;
+    get<T>(key: string, defaultValue: T): T;
+    get(key: string, defaultValue?: any): any {
+        return this.storage.has(key) ? this.storage.get(key) : defaultValue;
+    }
+
+    update(key: string, value: any): Thenable<void> {
+        this.storage.set(key, value);
+        return Promise.resolve();
+    }
+
+    keys(): readonly string[] {
+        return Array.from(this.storage.keys());
+    }
+
+    setKeysForSync(keys: readonly string[]): void {
+        // No-op
+    }
+}
+
+// Mock ExtensionContext
+class MockExtensionContext implements vscode.ExtensionContext {
+    globalState: vscode.Memento & { setKeysForSync(keys: readonly string[]): void } = new MockMemento();
+    subscriptions: { dispose(): any }[] = [];
+    workspaceState: vscode.Memento = new MockMemento();
+    extensionPath: string = '/mock/path';
+    storagePath: string | undefined = '/mock/storage';
+    globalStoragePath: string = '/mock/globalStorage';
+    logPath: string = '/mock/log';
+    asAbsolutePath(relativePath: string): string {
+        return `/mock/path/${relativePath}`;
+    }
+    storageUri: vscode.Uri | undefined = undefined;
+    globalStorageUri: vscode.Uri = vscode.Uri.file('/mock/globalStorage');
+    logUri: vscode.Uri = vscode.Uri.file('/mock/log');
+    extensionUri: vscode.Uri = vscode.Uri.file('/mock/path');
+    environmentVariableCollection: any;
+    extension: any = {
+        packageJSON: {
+            version: '0.0.0-test'
+        }
+    };
+    extensionMode: vscode.ExtensionMode = vscode.ExtensionMode.Test;
+
+    // Missing properties from newer VS Code API, added as any to satisfy TS if needed
+    secrets: any;
+    languageModelAccessInformation: any;
+}
+
+/**
+ * FilterManager Test Suite
+ * 
+ * Strategy:
+ * - Mocks ExtensionContext and GlobalState (Memento) to test persistence without VS Code API.
+ * - Handles 'initDefaultFilters' behavior where removing the last regex group triggers default re-creation.
+ * - Uses a 'Safe Group' (regex) to prevent automatic default restoration during tests.
+ */
+suite('FilterManager Export/Import Test Suite', () => {
+    let filterManager: FilterManager;
+    let mockContext: MockExtensionContext;
+
+    setup(() => {
+        mockContext = new MockExtensionContext();
+        filterManager = new FilterManager(mockContext);
+
+        // Clearing groups triggers 'initDefaultFilters' if we remove the last regex group.
+        // To strictly clean up, we can add a temporary regex group, remove others, then we are left with the temp one.
+        // But for these tests, we can just be careful.
+
+        // Let's try to remove everything locally, but knowing 'Presets' might come back if we aren't careful.
+        // Strategy: Add a 'Safe' regex group first.
+        const safeGroup = filterManager.addGroup('Safe Group', true);
+
+        // now remove all others
+        const groups = filterManager.getGroups();
+        [...groups].forEach(g => {
+            if (g.id !== safeGroup?.id) {
+                filterManager.removeGroup(g.id);
+            }
+        });
+
+        // Now we only have 'Safe Group'. We can leave it or try to remove it inside tests if needed, 
+        // but 'removeGroup(safeGroup)' would trigger defaults again.
+        // So let's just make sure our tests expect 'Safe Group' or we work around it.
+
+        // Actually, cleaner: Modify the tests to accept `Safe Group` presence or just filter it out from verification.
+        // OR: Modify the test to create its own groups, then remove 'Safe Group' *immediately* after creating the test regex group.
+    });
+
+    test('Export Single Group', () => {
+        // 1. Create a group with filters
+        const group = filterManager.addGroup('Test Group', false)!;
+        filterManager.addFilter(group.id, 'Test Filter', 'include', false);
+
+        // 2. Export
+        const json = filterManager.exportGroup(group.id);
+        assert.ok(json, 'Export should return JSON string');
+
+        // 3. Verify
+        const parsed = JSON.parse(json);
+        assert.strictEqual(parsed.version, '0.0.0-test');
+        assert.strictEqual(parsed.groups.length, 1);
+        assert.strictEqual(parsed.groups[0].name, 'Test Group');
+        assert.strictEqual(parsed.groups[0].filters.length, 1);
+        assert.strictEqual(parsed.groups[0].filters[0].keyword, 'Test Filter');
+    });
+
+    test('Export All Filters (Word Mode)', () => {
+        // 1. Create Word Group
+        const wGroup = filterManager.addGroup('Word Group', false)!;
+        filterManager.addFilter(wGroup.id, 'foo', 'include');
+
+        // 2. Create Regex Group (Should be ignored in 'word' export)
+        // The 'Safe Group' from setup is already a regex group, so this is redundant for the test's purpose.
+        // const rGroup = filterManager.addGroup('Regex Group', true)!;
+        // filterManager.addFilter(rGroup.id, '.*', 'include', true);
+
+        // 3. Export Word
+        const json = filterManager.exportFilters('word');
+        const parsed = JSON.parse(json);
+
+        // 4. Verify
+        // We know 'Safe Group' is regex, so it shouldn't be here.
+        assert.strictEqual(parsed.groups.length, 1, 'Should only export 1 group (Word Group)');
+        assert.strictEqual(parsed.groups[0].name, 'Word Group');
+    });
+
+    test('Export All Filters (Regex Mode)', () => {
+        // 1. Create Word Group (Should be ignored)
+        const wGroup = filterManager.addGroup('Word Group', false)!;
+
+        // 2. Create Regex Group
+        const rGroup = filterManager.addGroup('Regex Group', true)!;
+        filterManager.addFilter(rGroup.id, '.*', 'include', true);
+
+        // 2. Remove 'Safe Group' (Now that we have another regex group, this won't trigger defaults)
+        const groups = filterManager.getGroups();
+        const safe = groups.find(g => g.name === 'Safe Group');
+        if (safe) {
+            filterManager.removeGroup(safe.id);
+        }
+
+        // 3. Export Regex
+        const json = filterManager.exportFilters('regex');
+        const parsed = JSON.parse(json);
+
+        // 4. Verify
+        assert.strictEqual(parsed.groups.length, 1, 'Should only export 1 group');
+        assert.strictEqual(parsed.groups[0].name, 'Regex Group');
+    });
+
+    test('Import Filters', () => {
+        // 1. Prepare JSON to import
+        const importData = {
+            version: '1.0.0',
+            groups: [
+                {
+                    id: 'imp-1',
+                    name: 'Imported Group',
+                    isRegex: false,
+                    isEnabled: true,
+                    filters: [
+                        {
+                            id: 'f-1',
+                            keyword: 'Imported Key',
+                            type: 'include',
+                            isEnabled: true
+                        }
+                    ]
+                }
+            ]
+        };
+        const json = JSON.stringify(importData);
+
+        // 2. Import
+        const result = filterManager.importFilters(json, 'word', false);
+
+        // 3. Verify
+        assert.strictEqual(result.count, 1, 'Should have imported 1 group');
+
+        const groups = filterManager.getGroups();
+        // Since we cleared defaults in setup, should describe imported group
+        const importedGroup = groups.find(g => g.name === 'Imported Group');
+        assert.ok(importedGroup, 'Imported group should exist');
+        assert.strictEqual(importedGroup.filters.length, 1);
+        assert.strictEqual(importedGroup.filters[0].keyword, 'Imported Key');
+    });
+
+    test('Import Filters with Overwrite', () => {
+        // 1. Create existing group
+        filterManager.addGroup('Existing Group', false);
+
+        // 2. Prepare JSON
+        const importData = {
+            version: '1.0.0',
+            groups: [
+                {
+                    name: 'New Group',
+                    isRegex: false, // Matches 'word' mode
+                    filters: []
+                }
+            ]
+        };
+        const json = JSON.stringify(importData);
+
+        // 3. Import with Overwrite = true
+        // This will clear existing groups of same mode ('word').
+        // 'Safe Group' is regex, so it stays.
+        // 'Existing Group' is word, so it goes.
+        filterManager.importFilters(json, 'word', true);
+
+        // 4. Verify
+        const groups = filterManager.getGroups();
+        const wordGroups = groups.filter(g => !g.isRegex);
+
+        assert.strictEqual(wordGroups.length, 1, 'Should have exactly 1 word group after overwrite');
+        assert.strictEqual(wordGroups[0].name, 'New Group');
+    });
+});

--- a/src/test/services/LogProcessorIntegration.test.ts
+++ b/src/test/services/LogProcessorIntegration.test.ts
@@ -1,0 +1,212 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as fs from 'fs';
+import { LogProcessor } from '../../services/LogProcessor';
+import { FilterGroup, FilterItem, FilterType } from '../../models/Filter';
+import { Constants } from '../../constants';
+// Mock VS Codde
+import * as vscode from 'vscode';
+
+/**
+ * LogProcessor Integration Test Suite
+ * 
+ * Verifies the end-to-end log processing and filtering logic using real file I/O.
+ * Uses a sample log file (src/test/resources/sample.log) and expected output.
+ */
+suite('LogProcessor Integration Test Suite', () => {
+    let processor: LogProcessor;
+    const resourcesDir = path.join(__dirname, '..', '..', '..', 'src', 'test', 'resources');
+    const sampleLogPath = path.join(resourcesDir, 'sample.log');
+    const expectedOutputPath = path.join(resourcesDir, 'expected_filtered.log');
+
+    // Helper to create a basic filter group
+    function createGroup(id: string, name: string, enabled: boolean = true): FilterGroup {
+        return {
+            id,
+            name,
+            filters: [],
+            isEnabled: enabled,
+            isRegex: false,
+            isExpanded: true
+        };
+    }
+
+    // Helper to create a filter item
+    function createFilter(id: string, keyword: string, type: FilterType, enabled: boolean = true, isRegex: boolean = false, contextLine: number = 0, caseSensitive: boolean = false): FilterItem {
+        return {
+            id,
+            keyword,
+            type,
+            isEnabled: enabled,
+            isRegex,
+            contextLine,
+            caseSensitive
+        };
+    }
+
+    setup(() => {
+        processor = new LogProcessor();
+    });
+
+    test('processFile: should correctly filter log file based on "Error" keyword', async () => {
+        const filterGroup = createGroup('test-group', 'Test Group');
+        filterGroup.filters.push(createFilter('filter-1', 'Error', 'include'));
+
+        const result = await processor.processFile(sampleLogPath, [filterGroup]);
+
+        assert.ok(result.processed > 0, 'Should have processed lines');
+        assert.strictEqual(result.matched, 2, 'Should match 2 lines');
+
+        const actualContent = fs.readFileSync(result.outputPath, 'utf8');
+        const expectedContent = fs.readFileSync(expectedOutputPath, 'utf8');
+        assert.strictEqual(actualContent.trim(), expectedContent.trim(), 'Filtered output should match expected content');
+
+        if (fs.existsSync(result.outputPath)) {
+            fs.unlinkSync(result.outputPath);
+        }
+    });
+
+    test('processFile: Case Sensitivity', async () => {
+        const filterGroup = createGroup('case-group', 'Case Group');
+
+        // 1. Case Sensitive "error" (should not match "ERROR")
+        const caseSensitiveFilter = createFilter('filter-case', 'error', 'include', true, false, 0, true);
+
+        filterGroup.filters = [caseSensitiveFilter];
+
+        const result1 = await processor.processFile(sampleLogPath, [filterGroup]);
+        assert.strictEqual(result1.matched, 0, 'Should match 0 lines for case-sensitive lowercase "error"');
+        if (fs.existsSync(result1.outputPath)) {
+            fs.unlinkSync(result1.outputPath);
+        }
+
+        // 2. Case Insensitive "error" (should match "ERROR")
+        caseSensitiveFilter.caseSensitive = false;
+        const result2 = await processor.processFile(sampleLogPath, [filterGroup]);
+        assert.strictEqual(result2.matched, 2, 'Should match 2 lines for case-insensitive "error"');
+        if (fs.existsSync(result2.outputPath)) {
+            fs.unlinkSync(result2.outputPath);
+        }
+    });
+
+    test('processFile: Include and Exclude combination', async () => {
+        // Include "INFO", Exclude "Network"
+        // sample.log lines with INFO:
+        // 1. INFO [Main] Application started
+        // 2. INFO [Network] Connected  <-- Should be excluded
+        // 3. INFO [DB] Retrying connection...
+        // 4. INFO [Main] Shutting down
+        // expected: 1, 3, 4 (Total 3)
+
+        const filterGroup = createGroup('combo-group', 'Combo');
+        filterGroup.filters.push(createFilter('include-info', 'INFO', 'include'));
+        filterGroup.filters.push(createFilter('exclude-network', 'Network', 'exclude'));
+
+        const result = await processor.processFile(sampleLogPath, [filterGroup]);
+        assert.strictEqual(result.matched, 3, 'Should match 3 lines (INFO excluding Network)');
+
+        if (fs.existsSync(result.outputPath)) {
+            fs.unlinkSync(result.outputPath);
+        }
+    });
+
+    test('processFile: Enabled/Disabled Filters', async () => {
+        const filterGroup = createGroup('toggle-group', 'Toggle');
+
+        // Add disabled "ERROR" filter. 
+        // Since no active includes are present, it should match EVERYTHING (default behavior when no includes defined).
+        const disabledFilter = createFilter('disabled-error', 'ERROR', 'include', false);
+        filterGroup.filters.push(disabledFilter);
+
+        const result1 = await processor.processFile(sampleLogPath, [filterGroup]);
+
+        const totalLines = 7; // Based on sample.log content
+        assert.strictEqual(result1.matched, totalLines, 'Should match all lines when no active include filters exist');
+        if (fs.existsSync(result1.outputPath)) {
+            fs.unlinkSync(result1.outputPath);
+        }
+
+        // Now enable it
+        disabledFilter.isEnabled = true;
+        const result2 = await processor.processFile(sampleLogPath, [filterGroup]);
+        assert.strictEqual(result2.matched, 2, 'Should match 2 lines when filter is enabled');
+        if (fs.existsSync(result2.outputPath)) {
+            fs.unlinkSync(result2.outputPath);
+        }
+    });
+
+    test('processFile: Multiple Groups (Enabled + Disabled)', async () => {
+        // Group 1: Enabled, Include "ERROR" (Matches 2)
+        const group1 = createGroup('g1', 'Enabled Group', true);
+        group1.filters.push(createFilter('f1', 'ERROR', 'include'));
+
+        // Group 2: Disabled, Include "INFO" (Would match 4)
+        const group2 = createGroup('g2', 'Disabled Group', false); // Enabled = false
+        group2.filters.push(createFilter('f2', 'INFO', 'include'));
+
+        const result = await processor.processFile(sampleLogPath, [group1, group2]);
+
+        // Should only apply Group 1
+        assert.strictEqual(result.matched, 2, 'Should only match filters from enabled group');
+        if (fs.existsSync(result.outputPath)) {
+            fs.unlinkSync(result.outputPath);
+        }
+    });
+
+    test('processFile: Context Lines', async () => {
+        // Filter "Retrying" (Line 5 in sample.log) with context 1.
+        // Line 4: 2023-10-27 10:00:02.000 ERROR [DB] Connection failed
+        // Line 5: 2023-10-27 10:00:02.100 INFO  [DB] Retrying connection...
+        // Line 6: 2023-10-27 10:00:03.000 ERROR [DB] Connection failed again
+
+        // Should output lines 4, 5, 6. Total 3 lines.
+
+        const filterGroup = createGroup('context-group', 'Context');
+        const contextFilter = createFilter('f-context', 'Retrying', 'include');
+        contextFilter.contextLine = 1;
+        filterGroup.filters.push(contextFilter);
+
+        const result = await processor.processFile(sampleLogPath, [filterGroup]);
+
+        assert.strictEqual(result.matched, 1, 'Should register 1 primary match');
+        // Note: result.matched counts the primary matches. The output file line count includes context.
+        // Let's verify output line count.
+
+        const content = fs.readFileSync(result.outputPath, 'utf8').trim().split('\n');
+        assert.strictEqual(content.length, 3, 'Output should verify 3 lines (1 match + 1 before + 1 after)');
+        assert.ok(content[0].includes('Connection failed'), 'Line before');
+        assert.ok(content[1].includes('Retrying'), 'Match line');
+        assert.ok(content[2].includes('Connection failed again'), 'Line after');
+
+        if (fs.existsSync(result.outputPath)) {
+            fs.unlinkSync(result.outputPath);
+        }
+    });
+
+    test('processFile: Android Log Test', async () => {
+        const androidLogPath = path.join(resourcesDir, 'test_log_android.log');
+        const androidGroupPath = path.join(resourcesDir, 'test_group_android.json');
+        const androidExpectedPath = path.join(resourcesDir, 'test_log_android_filtered.log');
+
+        // 1. Load Filter Params
+        const groupContent = fs.readFileSync(androidGroupPath, 'utf8');
+        const parsedContext = JSON.parse(groupContent);
+        const groups = parsedContext.groups as FilterGroup[];
+
+        // 2. Process
+        const result = await processor.processFile(androidLogPath, groups);
+
+        // 3. Verify
+        assert.ok(result.processed > 0, 'Should handle 200~ lines');
+
+        const actualContent = fs.readFileSync(result.outputPath, 'utf8');
+        const expectedContent = fs.readFileSync(androidExpectedPath, 'utf8');
+
+        // Normalize line endings for cross-platform comparison if needed, though usually trim() helps.
+        assert.strictEqual(actualContent.trim(), expectedContent.trim(), 'Android filtered output should match');
+
+        if (fs.existsSync(result.outputPath)) {
+            fs.unlinkSync(result.outputPath);
+        }
+    });
+});


### PR DESCRIPTION
Expand the regression test suite to cover more filtering scenarios and add unit tests for filter export/import functionality.

- Add LogProcessorIntegration.test.ts:
  - Cover case sensitivity, include/exclude logic, enabled/disabled states, multiple groups, and context lines.
  - Add Android log test case using 'test_log_android.log' and 'test_group_android.json'.
- Add FilterManager.test.ts:
  - Verify export/import of single groups and full filter sets.
  - Test overwrite functionality during import.
- Add test resources:
  - sample.log, test_log_android.log, and expected output files.