### PR TITLE
cmd: add command to clear all persistent data

### DIFF
--- a/package.json
+++ b/package.json
@@ -523,6 +523,11 @@
         "icon": "$(trash)"
       },
       {
+        "command": "logmagnifier.clearAllData",
+        "title": "Clear All Persistent Data",
+        "icon": "$(trash)"
+      },
+      {
         "command": "logmagnifier.enableGroup",
         "title": "Enable",
         "icon": "$(circle-large-outline)",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -136,6 +136,7 @@ export const Constants = {
         ControlStartScreenRecord: 'logmagnifier.control.startScreenRecord',
         ControlStopScreenRecord: 'logmagnifier.control.stopScreenRecord',
         ControlToggleShowTouches: 'logmagnifier.control.toggleShowTouches',
+        ClearAllData: 'logmagnifier.clearAllData',
 
         // Bookmark
         AddBookmark: 'logmagnifier.addBookmark',
@@ -255,6 +256,8 @@ export const Constants = {
         ExportGroup: 'Export Group: {0}',
         ImportWordFilters: 'Import Word Filters',
         ImportRegexFilters: 'Import Regex Filters',
+        ConfirmClearAllData: 'Are you sure you want to clear ALL persistent data? This includes all profiles, filters, and bookmarks. This action cannot be undone.',
+        ReloadConfirm: 'Reload window now to apply changes?',
     },
 
     PlaceHolders: {
@@ -332,6 +335,7 @@ export const Constants = {
             UninstallCompleted: 'Uninstall completed. Please refresh the device list.',
             ClearStorageCompleted: 'Clear storage completed. Please refresh if needed.',
             ClearCacheCompleted: 'Clear cache completed. Please refresh if needed.',
+            ClearAllDataCompleted: 'All data cleared.',
             RecordingStarted: 'Recording started... (Max 3 mins)',
             SelectTextFirst: 'Please select some text first.',
             NoMatchesForText: 'No matches found for \'{0}\'.',

--- a/src/services/CommandManager.ts
+++ b/src/services/CommandManager.ts
@@ -122,6 +122,36 @@ export class CommandManager {
         this.registerExportImportCommands();
         this.registerNavigateCommands();
         this.registerProfileCommands();
+        this.registerClearDataCommand();
+    }
+
+    private registerClearDataCommand() {
+        this.context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.ClearAllData, async () => {
+            const answer = await vscode.window.showWarningMessage(
+                Constants.Prompts.ConfirmClearAllData,
+                { modal: true },
+                'Yes'
+            );
+
+            if (answer === 'Yes') {
+                // Clear all globalState
+                const keys = this.context.globalState.keys();
+                for (const key of keys) {
+                    this.logger.info(`Clearing globalState key: ${key}`);
+                    await this.context.globalState.update(key, undefined);
+                }
+
+                // Show success and ask for reload
+                const reload = await vscode.window.showInformationMessage(
+                    Constants.Messages.Info.ClearAllDataCompleted,
+                    Constants.Prompts.ReloadConfirm
+                );
+
+                if (reload === Constants.Prompts.ReloadConfirm) {
+                    vscode.commands.executeCommand('workbench.action.reloadWindow');
+                }
+            }
+        }));
     }
 
     private handleFilterToggle(item: FilterItem, action: 'enable' | 'disable' | 'toggle') {


### PR DESCRIPTION
This patch adds a new command `LogMagnifier: Clear All Persistent Data` to allow users to reset the extension to its factory state.

The command performs the following:
1. Displays a confirmation dialog to prevent accidental data loss.
2. Iterates through all keys in `context.globalState` and removes them.
3. Logs the deleted keys for debugging purposes.
4. Prompts the user to reload the window to apply changes effectively.

This feature is useful for debugging or when a user wants a completely fresh start with the extension.