### PR TITLE
profile: enhance persistence and add integration tests

### DIFF
--- a/src/services/FilterManager.ts
+++ b/src/services/FilterManager.ts
@@ -804,6 +804,30 @@ export class FilterManager implements vscode.Disposable {
         }
     }
 
+    public async duplicateProfile(name: string): Promise<boolean> {
+        // Just save detailed current groups to the new profile name
+        // This effectively duplicates the current state
+        try {
+            // Check if profile exists first to prevent overwrite if desired,
+            // but createProfile already checks this.
+            // saveProfile updates if exists, createProfile checks collision.
+            // We want 'Create copy' semantic, so fail if exists.
+
+            // Check existence via profile manager logic or just try create
+            const profiles = this.profileManager.getProfileNames();
+            if (profiles.includes(name)) {
+                return false;
+            }
+
+            await this.profileManager.updateProfileData(name, this.groups);
+            this.logger.info(`Duplicated current profile to: ${name}`);
+            return true;
+        } catch (e) {
+            this.logger.error(`Failed to duplicate profile: ${e}`);
+            return false;
+        }
+    }
+
     public async loadProfile(name: string): Promise<boolean> {
         const groups = await this.profileManager.loadProfile(name);
 

--- a/src/test/services/FilterManager.test.ts
+++ b/src/test/services/FilterManager.test.ts
@@ -3,59 +3,7 @@ import * as vscode from 'vscode';
 import { FilterManager } from '../../services/FilterManager';
 import { FilterGroup, FilterItem, FilterType } from '../../models/Filter';
 import { Constants } from '../../constants';
-
-// Mock Memento for GlobalState
-class MockMemento implements vscode.Memento {
-    private storage = new Map<string, any>();
-
-    get<T>(key: string): T | undefined;
-    get<T>(key: string, defaultValue: T): T;
-    get(key: string, defaultValue?: any): any {
-        return this.storage.has(key) ? this.storage.get(key) : defaultValue;
-    }
-
-    update(key: string, value: any): Thenable<void> {
-        this.storage.set(key, value);
-        return Promise.resolve();
-    }
-
-    keys(): readonly string[] {
-        return Array.from(this.storage.keys());
-    }
-
-    setKeysForSync(keys: readonly string[]): void {
-        // No-op
-    }
-}
-
-// Mock ExtensionContext
-class MockExtensionContext implements vscode.ExtensionContext {
-    globalState: vscode.Memento & { setKeysForSync(keys: readonly string[]): void } = new MockMemento();
-    subscriptions: { dispose(): any }[] = [];
-    workspaceState: vscode.Memento = new MockMemento();
-    extensionPath: string = '/mock/path';
-    storagePath: string | undefined = '/mock/storage';
-    globalStoragePath: string = '/mock/globalStorage';
-    logPath: string = '/mock/log';
-    asAbsolutePath(relativePath: string): string {
-        return `/mock/path/${relativePath}`;
-    }
-    storageUri: vscode.Uri | undefined = undefined;
-    globalStorageUri: vscode.Uri = vscode.Uri.file('/mock/globalStorage');
-    logUri: vscode.Uri = vscode.Uri.file('/mock/log');
-    extensionUri: vscode.Uri = vscode.Uri.file('/mock/path');
-    environmentVariableCollection: any;
-    extension: any = {
-        packageJSON: {
-            version: '0.0.0-test'
-        }
-    };
-    extensionMode: vscode.ExtensionMode = vscode.ExtensionMode.Test;
-
-    // Missing properties from newer VS Code API, added as any to satisfy TS if needed
-    secrets: any;
-    languageModelAccessInformation: any;
-}
+import { MockExtensionContext } from '../utils/Mocks';
 
 /**
  * FilterManager Test Suite

--- a/src/test/services/ProfileIntegration.test.ts
+++ b/src/test/services/ProfileIntegration.test.ts
@@ -1,0 +1,137 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { FilterManager } from '../../services/FilterManager';
+import { Constants } from '../../constants';
+import { MockExtensionContext } from '../utils/Mocks';
+
+suite('Profile Integration Test Suite', () => {
+    let filterManager: FilterManager;
+    let mockContext: MockExtensionContext;
+
+    setup(() => {
+        mockContext = new MockExtensionContext();
+        filterManager = new FilterManager(mockContext);
+
+        // Ensure clean state: Default profile is active initially
+    });
+
+    const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+    teardown(() => {
+        filterManager.dispose();
+    });
+
+    test('Default Profile Persistence', async () => {
+        // 1. Start on Default
+        assert.strictEqual(filterManager.getActiveProfile(), Constants.Labels.DefaultProfile);
+
+        // 2. Add a filter to default
+        const defaultGroup = filterManager.addGroup('Default Group', false)!;
+        filterManager.addFilter(defaultGroup.id, 'keyword1', 'include');
+        await wait(350); // Wait for debounce save
+
+        // 3. Create and switch to new profile
+        await filterManager.createProfile('Profile B');
+        assert.strictEqual(filterManager.getActiveProfile(), 'Profile B');
+
+        const profileBGroups = filterManager.getGroups();
+        // Should NOT have 'Default Group'
+        assert.ok(!profileBGroups.find(g => g.name === 'Default Group'), 'New profile should not have groups from previous profile');
+
+        // 4. Switch back to Default
+        await filterManager.loadProfile(Constants.Labels.DefaultProfile);
+        assert.strictEqual(filterManager.getActiveProfile(), Constants.Labels.DefaultProfile);
+
+        // 5. Verify persistence
+        const groups = filterManager.getGroups();
+        const persistedGroup = groups.find(g => g.name === 'Default Group');
+        assert.ok(persistedGroup, 'Default profile should persist its groups');
+        assert.strictEqual(persistedGroup.filters[0].keyword, 'keyword1');
+    });
+
+    test('Create New Profile', async () => {
+        const result = await filterManager.createProfile('New Profile');
+        assert.strictEqual(result, true);
+        assert.strictEqual(filterManager.getActiveProfile(), 'New Profile');
+
+        // Verify it exists in profile list
+        const profiles = filterManager.getProfileNames();
+        assert.ok(profiles.includes('New Profile'));
+    });
+
+    test('Duplicate Profile', async () => {
+        // 1. Setup initial profile
+        const group = filterManager.addGroup('Source Group', false)!;
+        filterManager.addFilter(group.id, 'source-filter', 'include');
+        await wait(350);
+
+        // 2. Duplicate
+        const dupResult = await filterManager.duplicateProfile('Copy Profile');
+        assert.strictEqual(dupResult, true, 'Duplication should succeed');
+
+        // 3. Switch to copy
+        await filterManager.loadProfile('Copy Profile');
+        assert.strictEqual(filterManager.getActiveProfile(), 'Copy Profile');
+
+        // 4. Verify content
+        const groups = filterManager.getGroups();
+
+        const copiedGroup = groups.find(g => g.name === 'Source Group');
+        assert.ok(copiedGroup, 'Copied profile should have source group');
+        assert.strictEqual(copiedGroup.filters[0].keyword, 'source-filter');
+    });
+
+    test('Profile Isolation', async () => {
+        // 1. Setup Profile A
+        await filterManager.createProfile('Profile A');
+        const groupA = filterManager.addGroup('Group A', false)!;
+        filterManager.addFilter(groupA.id, 'filter A', 'include');
+        await wait(350);
+
+        // 2. Duplicate to Profile B
+        await filterManager.duplicateProfile('Profile B');
+        await filterManager.loadProfile('Profile B');
+
+        // 3. Modify Profile B
+        const groupB = filterManager.getGroups().find(g => g.name === 'Group A')!;
+        filterManager.addFilter(groupB.id, 'filter B', 'exclude');
+        await wait(350);
+
+        // 4. Switch back to A
+        await filterManager.loadProfile('Profile A');
+
+        // 5. Verify A is unchanged
+        const finalGroupA = filterManager.getGroups().find(g => g.name === 'Group A')!;
+        assert.strictEqual(finalGroupA.filters.length, 1, 'Profile A should not be affected by changes in Profile B');
+        assert.strictEqual(finalGroupA.filters[0].keyword, 'filter A');
+    });
+
+    test('Export/Import per Profile', async () => {
+        // 1. Create Profile Export
+        await filterManager.createProfile('Export Source');
+        const exGroup = filterManager.addGroup('Export Group', false)!;
+        filterManager.addFilter(exGroup.id, 'export-keyword', 'include');
+        await wait(350);
+
+        const json = filterManager.exportFilters('word'); // Export word filters
+
+        // 2. Switch to Profile Import
+        await filterManager.createProfile('Import Target');
+        // Verify keys don't exist yet
+        assert.strictEqual(filterManager.getGroups().find(g => g.name === 'Export Group'), undefined);
+
+        // 3. Import
+        filterManager.importFilters(json, 'word', false);
+        await wait(350);
+
+        // 4. Verify Import
+        const groups = filterManager.getGroups();
+        const importedGroup = groups.find(g => g.name === 'Export Group');
+        assert.ok(importedGroup, 'Should have imported group');
+        assert.strictEqual(importedGroup.filters[0].keyword, 'export-keyword');
+
+        // 5. Verify Isolation (Switch back to Default)
+        await filterManager.loadProfile(Constants.Labels.DefaultProfile);
+        assert.strictEqual(filterManager.getGroups().find(g => g.name === 'Export Group'), undefined, 'Default profile should not receive imported groups from another profile');
+    });
+});

--- a/src/test/utils/Mocks.ts
+++ b/src/test/utils/Mocks.ts
@@ -1,0 +1,54 @@
+import * as vscode from 'vscode';
+
+// Mock Memento for GlobalState
+export class MockMemento implements vscode.Memento {
+    private storage = new Map<string, any>();
+
+    get<T>(key: string): T | undefined;
+    get<T>(key: string, defaultValue: T): T;
+    get(key: string, defaultValue?: any): any {
+        return this.storage.has(key) ? this.storage.get(key) : defaultValue;
+    }
+
+    update(key: string, value: any): Thenable<void> {
+        this.storage.set(key, value);
+        return Promise.resolve();
+    }
+
+    keys(): readonly string[] {
+        return Array.from(this.storage.keys());
+    }
+
+    setKeysForSync(keys: readonly string[]): void {
+        // No-op
+    }
+}
+
+// Mock ExtensionContext
+export class MockExtensionContext implements vscode.ExtensionContext {
+    globalState: vscode.Memento & { setKeysForSync(keys: readonly string[]): void } = new MockMemento();
+    subscriptions: { dispose(): any }[] = [];
+    workspaceState: vscode.Memento = new MockMemento();
+    extensionPath: string = '/mock/path';
+    storagePath: string | undefined = '/mock/storage';
+    globalStoragePath: string = '/mock/globalStorage';
+    logPath: string = '/mock/log';
+    asAbsolutePath(relativePath: string): string {
+        return `/mock/path/${relativePath}`;
+    }
+    storageUri: vscode.Uri | undefined = undefined;
+    globalStorageUri: vscode.Uri = vscode.Uri.file('/mock/globalStorage');
+    logUri: vscode.Uri = vscode.Uri.file('/mock/log');
+    extensionUri: vscode.Uri = vscode.Uri.file('/mock/path');
+    environmentVariableCollection: any;
+    extension: any = {
+        packageJSON: {
+            version: '0.0.0-test'
+        }
+    };
+    extensionMode: vscode.ExtensionMode = vscode.ExtensionMode.Test;
+
+    // Missing properties from newer VS Code API, added as any to satisfy TS if needed
+    secrets: any;
+    languageModelAccessInformation: any;
+}


### PR DESCRIPTION
Enable persistence for the Default Profile to ensure filter state is retained when switching profiles. Add a dedicated duplicateProfile method in FilterManager for better testability.

Refactor test mocks into shared utilities and add comprehensive integration tests for profile creation, duplication, isolation, and export/import data flows.