### PR TITLE
refactor: apply code review cleanup

### DIFF
--- a/src/services/AdbService.ts
+++ b/src/services/AdbService.ts
@@ -842,7 +842,6 @@ export class AdbService implements vscode.Disposable {
 
         const checkLoop = async () => {
             while (attempts < maxAttempts) {
-                const lsCmd = `${adbPath} -s ${deviceId} shell ls -l ${remotePath}`;
 
                 const result = await new Promise<{ size: number, output: string }>((resolve) => {
                     cp.execFile(adbPath, ['-s', deviceId, 'shell', 'ls', '-l', remotePath], (err, stdout) => {
@@ -960,7 +959,6 @@ export class AdbService implements vscode.Disposable {
         const current = await this.getShowTouchesState(deviceId);
         await this.setShowTouchesState(deviceId, !current);
     }
-
 
     public dispose() {
         this.flushTimers.forEach(timer => clearInterval(timer));

--- a/src/services/HighlightService.ts
+++ b/src/services/HighlightService.ts
@@ -377,7 +377,7 @@ export class HighlightService implements vscode.Disposable {
                     if (regex.test(text)) {
                         return filter.color || (typeof defaultColor === 'string' ? defaultColor : undefined);
                     }
-                } catch (e) { }
+                } catch (e) { /* ignore invalid regex */ }
             }
         }
         return undefined;

--- a/src/services/LogBookmarkService.ts
+++ b/src/services/LogBookmarkService.ts
@@ -276,7 +276,6 @@ export class LogBookmarkService implements vscode.Disposable {
         }
     }
 
-
     public getActiveLinesCount(): number {
         // Legacy/Global count: sum of all files
         let total = 0;

--- a/src/services/LogProcessor.ts
+++ b/src/services/LogProcessor.ts
@@ -215,5 +215,4 @@ export class LogProcessor {
 
         return { isMatched, contextLines: maxContext };
     }
-
 }

--- a/src/views/LogBookmarkWebviewProvider.ts
+++ b/src/views/LogBookmarkWebviewProvider.ts
@@ -236,7 +236,6 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
         }
     }
 
-
     private updateContent() {
         if (!this._view) {
             return;
@@ -259,7 +258,6 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
         let sortedUris = this._bookmarkService.getFileKeys();
 
         // LIFO order implies no re-sorting of active file to top
-
 
         // Check active editor if not set (initial load)
         if (!this._activeUriStr && vscode.window.activeTextEditor) {
@@ -326,9 +324,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
                 </span>
             `).join('');
 
-
             const lineCount = this._bookmarkService.getFileActiveLinesCount(uriStr);
-
 
             // Group items by line
             const lineItemsMap = new Map<number, typeof items>();


### PR DESCRIPTION
Address minor issues from the code review report v2.

- Remove unused `lsCmd` variable in AdbService.
- Remove consecutive and trailing blank lines in multiple files for better readability.
- Add explanatory comment to an empty catch block in HighlightService.