### PR TITLE
refactor: fix eslint warnings and improve type safety

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import { JsonTreeWebview } from './views/JsonTreeWebview';
 import { SourceMapService } from './services/SourceMapService';
 import { FilteredLogDefinitionProvider } from './providers/FilteredLogDefinitionProvider';
 import { Constants } from './constants';
+import { FilterGroup, FilterItem } from './models/Filter';
 
 let debounceTimer: NodeJS.Timeout | undefined;
 
@@ -66,7 +67,7 @@ export function activate(context: vscode.ExtensionContext) {
         return typeof item === 'object' && item !== null && Array.isArray((item as import('./models/Filter').FilterGroup).filters);
     };
 
-    const setupExpansionSync = (view: vscode.TreeView<any>) => {
+    const setupExpansionSync = (view: vscode.TreeView<FilterGroup | FilterItem>) => {
         context.subscriptions.push(view.onDidExpandElement(e => {
             if (isGroup(e.element)) {
                 filterManager.setGroupExpanded(e.element.id, true);

--- a/src/services/AdbService.ts
+++ b/src/services/AdbService.ts
@@ -62,7 +62,7 @@ export class AdbService implements vscode.Disposable {
                                 if (key === 'transport_id') {
                                     device.transportId = value;
                                 } else {
-                                    (device as any)[key] = value;
+                                    (device as unknown as Record<string, unknown>)[key] = value;
                                 }
                             }
                         }

--- a/src/services/HighlightService.ts
+++ b/src/services/HighlightService.ts
@@ -6,9 +6,19 @@ import { FilterItem } from '../models/Filter';
 import { Logger } from './Logger';
 import { RegexUtils } from '../utils/RegexUtils';
 
+export type HighlightColor = string | { light: string; dark: string };
+
+export interface DecorationConfig {
+    colorNameOrValue: HighlightColor | undefined;
+    isFullLine: boolean;
+    textDecoration?: string;
+    fontWeight?: string;
+    textColor?: string;
+}
+
 export class HighlightService implements vscode.Disposable {
     // Map of color string -> DecorationType
-    private decorationTypes: Map<string, { decoration: vscode.TextEditorDecorationType, config: any }> = new Map();
+    private decorationTypes: Map<string, { decoration: vscode.TextEditorDecorationType, config: DecorationConfig }> = new Map();
     private activeFlashDecoration: vscode.TextEditorDecorationType | undefined;
     private activeFlashTimeout: NodeJS.Timeout | undefined;
 
@@ -17,7 +27,7 @@ export class HighlightService implements vscode.Disposable {
         private logger: Logger
     ) { }
 
-    private getDecorationKey(colorNameOrValue: string | { light: string, dark: string } | undefined, isFullLine: boolean, textDecoration?: string, fontWeight?: string, textColor?: string): string {
+    private getDecorationKey(colorNameOrValue: HighlightColor | undefined, isFullLine: boolean, textDecoration?: string, fontWeight?: string, textColor?: string): string {
         let colorKey = 'undefined';
         if (typeof colorNameOrValue === 'string') {
             const preset = this.filterManager.getPresetById(colorNameOrValue);
@@ -33,7 +43,7 @@ export class HighlightService implements vscode.Disposable {
         return `${colorKey}_${isFullLine}_${textDecoration || ''}_${fontWeight || 'auto'}_${textColor || 'auto'}`;
     }
 
-    private getDecorationInfo(colorNameOrValue: string | { light: string, dark: string } | undefined, isFullLine: boolean = false, textDecoration?: string, fontWeight?: string, textColor?: string): { decoration: vscode.TextEditorDecorationType, config: any } {
+    private getDecorationInfo(colorNameOrValue: HighlightColor | undefined, isFullLine: boolean = false, textDecoration?: string, fontWeight?: string, textColor?: string): { decoration: vscode.TextEditorDecorationType, config: DecorationConfig } {
         const key = this.getDecorationKey(colorNameOrValue, isFullLine, textDecoration, fontWeight, textColor);
 
         if (!this.decorationTypes.has(key)) {
@@ -203,7 +213,7 @@ export class HighlightService implements vscode.Disposable {
         text: string,
         filter: FilterItem,
         groupId: string,
-        defaultColor: any,
+        defaultColor: HighlightColor,
         rangesByDeco: Map<string, vscode.Range[]>,
         matchCounts: Map<string, number>,
         offset: number
@@ -213,7 +223,7 @@ export class HighlightService implements vscode.Disposable {
         }
 
         const isExclude = filter.type === 'exclude';
-        const decoRequests: { color: any, isFullLine: boolean, textDecoration?: string, fontWeight?: string, useLineRange: boolean, textColor?: string }[] = [];
+        const decoRequests: { color: HighlightColor | undefined, isFullLine: boolean, textDecoration?: string, fontWeight?: string, useLineRange: boolean, textColor?: string }[] = [];
 
         if (isExclude) {
             const style = filter.excludeStyle || 'line-through';

--- a/src/services/JsonPrettyService.ts
+++ b/src/services/JsonPrettyService.ts
@@ -10,7 +10,7 @@ import { EditorUtils } from '../utils/EditorUtils';
 interface ExtractedJson {
     type: 'valid' | 'invalid' | 'incomplete';
     text: string;
-    parsed?: any;
+    parsed?: unknown;
     error?: string;
 }
 

--- a/src/services/LenientJsonParser.ts
+++ b/src/services/LenientJsonParser.ts
@@ -7,7 +7,7 @@
  */
 export interface ParsedNode {
     type: 'object' | 'array' | 'string' | 'number' | 'boolean' | 'null' | 'undefined';
-    value?: any;
+    value?: unknown;
     children?: ParsedProperty[];
     items?: ParsedNode[];
     isError?: boolean;
@@ -25,7 +25,7 @@ export class LenientJsonParser {
 
     constructor() { }
 
-    public static toParsedNode(data: any): ParsedNode {
+    public static toParsedNode(data: unknown): ParsedNode {
         if (data === null) { return { type: 'null', value: null }; }
         if (data === undefined) { return { type: 'undefined' }; }
 
@@ -35,9 +35,10 @@ export class LenientJsonParser {
         }
 
         if (typeof data === 'object') {
-            const children: ParsedProperty[] = Object.keys(data).map(key => ({
+            const obj = data as Record<string, unknown>;
+            const children: ParsedProperty[] = Object.keys(obj).map(key => ({
                 key,
-                value: this.toParsedNode(data[key])
+                value: this.toParsedNode(obj[key])
             }));
             return { type: 'object', children };
         }

--- a/src/services/LogBookmarkService.ts
+++ b/src/services/LogBookmarkService.ts
@@ -379,7 +379,7 @@ export class LogBookmarkService implements vscode.Disposable {
     }
 
     private async saveToState() {
-        const bookmarksData: { [key: string]: any[] } = {};
+        const bookmarksData: { [key: string]: unknown[] } = {};
         for (const [key, bookmarks] of this._bookmarks) {
             bookmarksData[key] = bookmarks.map(b => ({
                 id: b.id,
@@ -406,11 +406,12 @@ export class LogBookmarkService implements vscode.Disposable {
     }
 
     private loadFromState() {
-        const bookmarksData = this.context.globalState.get<{ [key: string]: any[] }>(Constants.GlobalState.Bookmarks);
+        const bookmarksData = this.context.globalState.get<{ [key: string]: unknown[] }>(Constants.GlobalState.Bookmarks);
 
         if (bookmarksData) {
             for (const key in bookmarksData) {
-                const bookmarks = bookmarksData[key].map(b => {
+                const bookmarks = bookmarksData[key].map(item => {
+                    const b = item as Record<string, unknown>; // Safe cast after check
                     try {
                         if (!b || typeof b !== 'object') {
                             return null;
@@ -420,12 +421,12 @@ export class LogBookmarkService implements vscode.Disposable {
                         }
 
                         return {
-                            id: b.id,
-                            uri: vscode.Uri.parse(b.uri),
+                            id: b.id as string,
+                            uri: vscode.Uri.parse(b.uri as string),
                             line: typeof b.line === 'number' ? b.line : 0,
-                            content: b.content || '',
-                            groupId: b.groupId || Date.now().toString(), // Fallback for old bookmarks
-                            matchText: b.matchText
+                            content: (b.content as string) || '',
+                            groupId: (b.groupId as string) || Date.now().toString(), // Fallback for old bookmarks
+                            matchText: b.matchText as string | undefined
                         } as BookmarkItem;
                     } catch (e) {
                         this.logger.error(`Error parsing bookmark from state: ${e}`);

--- a/src/test/services/BookmarkIntegration.test.ts
+++ b/src/test/services/BookmarkIntegration.test.ts
@@ -134,8 +134,6 @@ suite('Bookmark Integration Test Suite', () => {
         const editor = await vscode.window.showTextDocument(androidLogUri);
         bookmarkService.addBookmark(editor, 10);
 
-        const key = androidLogUri.toString();
-
         // 1. Toggle Word Wrap
         const initialWordWrap = bookmarkService.isWordWrapEnabled();
         await vscode.commands.executeCommand(Constants.Commands.ToggleBookmarkWordWrap);

--- a/src/test/services/DefinitionProviderIntegration.test.ts
+++ b/src/test/services/DefinitionProviderIntegration.test.ts
@@ -92,12 +92,10 @@ suite('FilteredLogDefinitionProvider Integration Test Suite', () => {
     });
 
     test('provideDefinition: should return undefined for document without mapping', async () => {
-        const dummyUri = vscode.Uri.file(path.join(resourcesDir, 'dummy.log'));
         // Ensure dummy.log exists or use a mock
         const doc = await vscode.workspace.openTextDocument(androidLogPath); // reuse existing doc but check against dummy logic
 
         // Use a URI that is NOT registered
-        const unregisteredUri = vscode.Uri.parse('file:///unregistered.log');
         // We can't easily "fake" the URI of an open document in VS Code API without saving it,
         // but FilteredLogDefinitionProvider checks document.uri.
 

--- a/src/test/services/LenientJsonParser.test.ts
+++ b/src/test/services/LenientJsonParser.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { LenientJsonParser, ParsedNode } from '../../services/LenientJsonParser';
+import { LenientJsonParser } from '../../services/LenientJsonParser';
 
 suite('LenientJsonParser Test Suite', () => {
     let parser: LenientJsonParser;

--- a/src/test/services/LogProcessorIntegration.test.ts
+++ b/src/test/services/LogProcessorIntegration.test.ts
@@ -3,9 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { LogProcessor } from '../../services/LogProcessor';
 import { FilterGroup, FilterItem, FilterType } from '../../models/Filter';
-import { Constants } from '../../constants';
 // Mock VS Codde
-import * as vscode from 'vscode';
 
 /**
  * LogProcessor Integration Test Suite

--- a/src/test/services/ProfileIntegration.test.ts
+++ b/src/test/services/ProfileIntegration.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import * as vscode from 'vscode';
+
 import { FilterManager } from '../../services/FilterManager';
 import { Constants } from '../../constants';
 import { MockExtensionContext } from '../utils/Mocks';

--- a/src/test/utils/Mocks.ts
+++ b/src/test/utils/Mocks.ts
@@ -2,15 +2,15 @@ import * as vscode from 'vscode';
 
 // Mock Memento for GlobalState
 export class MockMemento implements vscode.Memento {
-    private storage = new Map<string, any>();
+    private storage = new Map<string, unknown>();
 
     get<T>(key: string): T | undefined;
     get<T>(key: string, defaultValue: T): T;
-    get(key: string, defaultValue?: any): any {
+    get(key: string, defaultValue?: unknown): unknown {
         return this.storage.has(key) ? this.storage.get(key) : defaultValue;
     }
 
-    update(key: string, value: any): Thenable<void> {
+    update(key: string, value: unknown): Thenable<void> {
         this.storage.set(key, value);
         return Promise.resolve();
     }
@@ -19,7 +19,7 @@ export class MockMemento implements vscode.Memento {
         return Array.from(this.storage.keys());
     }
 
-    setKeysForSync(keys: readonly string[]): void {
+    setKeysForSync(_keys: readonly string[]): void {
         // No-op
     }
 }
@@ -27,6 +27,7 @@ export class MockMemento implements vscode.Memento {
 // Mock ExtensionContext
 export class MockExtensionContext implements vscode.ExtensionContext {
     globalState: vscode.Memento & { setKeysForSync(keys: readonly string[]): void } = new MockMemento();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     subscriptions: { dispose(): any }[] = [];
     workspaceState: vscode.Memento = new MockMemento();
     extensionPath: string = '/mock/path';
@@ -40,7 +41,9 @@ export class MockExtensionContext implements vscode.ExtensionContext {
     globalStorageUri: vscode.Uri = vscode.Uri.file('/mock/globalStorage');
     logUri: vscode.Uri = vscode.Uri.file('/mock/log');
     extensionUri: vscode.Uri = vscode.Uri.file('/mock/path');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     environmentVariableCollection: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     extension: any = {
         packageJSON: {
             version: '0.0.0-test'
@@ -49,6 +52,8 @@ export class MockExtensionContext implements vscode.ExtensionContext {
     extensionMode: vscode.ExtensionMode = vscode.ExtensionMode.Test;
 
     // Missing properties from newer VS Code API, added as any to satisfy TS if needed
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     secrets: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     languageModelAccessInformation: any;
 }

--- a/src/views/JsonTreeWebview.ts
+++ b/src/views/JsonTreeWebview.ts
@@ -9,7 +9,7 @@ export class JsonTreeWebview {
 
     constructor(private readonly context: vscode.ExtensionContext) { }
 
-    public show(data: any, title: string = 'JSON Preview', status: 'valid' | 'invalid' | 'no-json' = 'valid', tabSize: number = 2, sourceUri?: string, sourceLine?: number, preserveFocus: boolean = false) {
+    public show(data: unknown, title: string = 'JSON Preview', status: 'valid' | 'invalid' | 'no-json' = 'valid', tabSize: number = 2, sourceUri?: string, sourceLine?: number, preserveFocus: boolean = false) {
         if (this.panel) {
             const expansionDepth = this.context.globalState.get<number>('jsonPreview.expansionDepth', 1);
             this.panel.reveal(vscode.ViewColumn.Beside, preserveFocus);
@@ -54,7 +54,7 @@ export class JsonTreeWebview {
         return !!this.panel;
     }
 
-    private getHtmlForWebview(data: any, status: 'valid' | 'invalid' | 'no-json', tabSize: number = 2, sourceUri?: string, sourceLine?: number, expansionDepth: number = 1): string {
+    private getHtmlForWebview(data: unknown, status: 'valid' | 'invalid' | 'no-json', tabSize: number = 2, sourceUri?: string, sourceLine?: number, expansionDepth: number = 1): string {
         const initialData = JSON.stringify(data);
         const nonce = getNonce();
 


### PR DESCRIPTION
Address accumulated ESLint warnings to improve code maintainability and type safety.

Key changes:
- Replace `any` with `unknown` or specific interfaces (e.g., `HighlightColor`) in services and views.
- Remove unused variables and imports in test suites.
- Improve type assertions in `AdbService` and `LogBookmarkService`.
- Fix strict type checks in `HighlightService` and `LenientJsonParser`.