### PR TITLE
refactor: remove stale and conversational comments

### DIFF
--- a/src/services/JsonPrettyService.ts
+++ b/src/services/JsonPrettyService.ts
@@ -177,16 +177,13 @@ export class JsonPrettyService implements vscode.Disposable {
             });
 
             if (results.length > 0) {
-                // Pass array of results. We update the signature of show later.
-                // TypeScript might complain until we update the interface.
+                // Pass array of results.
                 const options = editor.options;
                 const tabSize = typeof options.tabSize === 'number' ? options.tabSize : 2;
 
                 // Extract source info
                 const sourceUri = editor.document.uri.toString();
-                // If selection is single line, use that.
-                // However, logProcessor extracted based on selection.active.line usually, or current line.
-                // Since this command uses active selection:
+                // Use the active line from the selection
                 const sourceLine = selection.active.line;
 
                 this.jsonTreeWebview.show(results, 'JSON Preview', 'valid', tabSize, sourceUri, sourceLine, silent);

--- a/src/services/SourceMapService.ts
+++ b/src/services/SourceMapService.ts
@@ -49,9 +49,7 @@ export class SourceMapService {
         }
 
         // Create a range for the target line (start to end of line)
-        // Since we don't have the original document open, we can just point to the start of the line.
-        // If the document is opened, we can refine this, but for now (0, 0) is sufficient to jump.
-        // Ideally, we want to jump to the start of the line.
+        // Point to the start of the line (0, 0)
         const position = new vscode.Position(originalLine, 0);
         return new vscode.Location(mapping.sourceUri, position);
     }

--- a/src/views/JsonTreeWebview.ts
+++ b/src/views/JsonTreeWebview.ts
@@ -187,9 +187,7 @@ export class JsonTreeWebview {
                     top: 50%;
                     transform: translateY(-50%);
                     font-size: 13px; /* Same as input font size */
-                    color: var(--button-hover-bg); /* Distinct color, reusing a variable or set specific */
-                    color: #007acc; /* Example distinct color (VSCode Blue approx) or use var */
-                    color: var(--vscode-textLink-foreground); /* Better distinct theme-aware color */
+                    color: var(--vscode-textLink-foreground);
                     pointer-events: none; /* Let clicks pass through to input */
                     white-space: nowrap;
                     text-align: right;

--- a/src/views/LogBookmarkWebviewProvider.ts
+++ b/src/views/LogBookmarkWebviewProvider.ts
@@ -365,9 +365,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
                     // Create a combined regex: (match1|match2|...)
                     // Escape each match text
                     const escapedMatches = Array.from(uniqueMatchTexts).map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-                    // distinct matching logic handled by simple joining?
-                    // Be careful about overlapping matches. Detailed tokenization is better but complex.
-                    // Simple approach: Construct one regex.
+                    // Construct one regex to handle all matches.
                     // Sort by length destending to match longest first (e.g. "Error" vs "Error Code")
                     escapedMatches.sort((a, b) => b.length - a.length);
 

--- a/src/views/QuickAccessProvider.ts
+++ b/src/views/QuickAccessProvider.ts
@@ -67,8 +67,7 @@ export class QuickAccessProvider implements vscode.TreeDataProvider<vscode.TreeI
         item.label = '──────────────';
         item.contextValue = 'separator';
         item.tooltip = undefined;
-        // Make it unclickable/disabled appearance if possible, but VS Code TreeItem doesn't have "disabled" state that prevents selection easily without command.
-        // We just don't assign a command.
+        // Separator item with no command.
         return item;
     }
 
@@ -90,8 +89,7 @@ export class QuickAccessProvider implements vscode.TreeDataProvider<vscode.TreeI
 
     public toggleFileSizeUnit(): void {
         const size = this.getFileSize();
-        // If undefined (error/no file), just toggle blindly or do nothing?
-        // If we can't determine size, we can't check for 0. Let's assume size is 0 if undefined.
+        // Treat undefined size (error/no file) as 0.
         const safeSize = size ?? 0;
 
         const order: ('bytes' | 'kb' | 'mb')[] = ['bytes', 'kb', 'mb'];
@@ -156,10 +154,7 @@ export class QuickAccessProvider implements vscode.TreeDataProvider<vscode.TreeI
         // item.description = isEnabled ? 'On' : 'Off'; // Moved to label for clarity
         item.iconPath = new vscode.ThemeIcon(iconId);
         // Add a visual indicator for state beyond just text
-        // We could use checkmark icon overlay, but for now Description + ContextValue is good.
-        // Or we could change the icon color via ThemeColor if VS Code API supported it easily on TreeItems.
-        // Let's stick to standard icons but maybe change the icon itself if off?
-        // User requested "buttons", so keeping the semantic icon is better.
+        // Use standard icons with text status indicator.
 
         item.command = {
             command: commandId,


### PR DESCRIPTION
Clean up outdated TODOs, redundant comments, and conversational notes across services and views to improve code professionalism and maintainability.

- Remove conversational notes in JsonTreeWebview and QuickAccessProvider.
- Remove redundant CSS and logic comments.
- Simplify comments in SourceMapService and LogBookmarkWebviewProvider.
- Remove outdated TODOs in JsonPrettyService.