### PR TITLE
refactor: replace synchronous filesystem calls with async APIs

### DIFF
--- a/src/utils/EditorUtils.ts
+++ b/src/utils/EditorUtils.ts
@@ -10,14 +10,6 @@ export class EditorUtils {
      *
      * @param lastActiveEditor Optional fallback if no active editor is directly found
      * @param operationName Optional name of the operation for specific error messages (e.g. "add bookmark")
-     * @returns The active text editor, or undefined if none found or file is too large
-     */
-    /**
-     * Tries to resolve the active text editor, prioritizing the active tab for large files
-     * to prevent falling back to incorrect visible editors.
-     *
-     * @param lastActiveEditor Optional fallback if no active editor is directly found
-     * @param operationName Optional name of the operation for specific error messages (e.g. "add bookmark")
      * @returns Promise resolving to the active text editor, or undefined if none found or file is too large
      */
     public static async getActiveEditorAsync(lastActiveEditor?: vscode.TextEditor, operationName: string = 'perform operation'): Promise<vscode.TextEditor | undefined> {

--- a/src/views/JsonTreeHtmlGenerator.ts
+++ b/src/views/JsonTreeHtmlGenerator.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import * as fs from 'fs';
+
 import * as path from 'path';
 import { getNonce } from '../utils/WebviewUtils';
 
@@ -21,7 +21,8 @@ export class JsonTreeHtmlGenerator {
 
         let html = '';
         try {
-            html = fs.readFileSync(templatePath.fsPath, 'utf8');
+            const templateBytes = await vscode.workspace.fs.readFile(templatePath);
+            html = new TextDecoder('utf-8').decode(templateBytes);
         } catch (err) {
             console.error('Failed to read JSON Tree template:', err);
             return `<html><body>Failed to load template. Error: ${err}</body></html>`;

--- a/src/views/LogBookmarkHtmlGenerator.ts
+++ b/src/views/LogBookmarkHtmlGenerator.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import * as fs from 'fs';
+
 import { LogBookmarkService } from '../services/LogBookmarkService';
 import { BookmarkItem } from '../models/Bookmark';
 import { SerializedBookmarkItem } from '../models/WebviewModels';
@@ -201,9 +201,11 @@ export class LogBookmarkHtmlGenerator {
             finalHtml = '<div class="empty-state">No bookmarks. Right-click on a line to add.</div>';
         }
 
-        const templatePath = vscode.Uri.joinPath(this._extensionUri, 'resources', 'webview', 'log-bookmark-template.html').fsPath;
+        const templatePath = vscode.Uri.joinPath(this._extensionUri, 'resources', 'webview', 'log-bookmark-template.html');
         try {
-            let template = fs.readFileSync(templatePath, 'utf8');
+            const templateBytes = await vscode.workspace.fs.readFile(templatePath);
+            let template = new TextDecoder('utf-8').decode(templateBytes);
+
             template = template.replace(/{{\s*CSP_SOURCE\s*}}/g, webview.cspSource);
             template = template.replace(/{{\s*NONCE\s*}}/g, nonce);
             template = template.replace(/{{\s*NAV_BAR\s*}}/g, headerButtonsHtml);


### PR DESCRIPTION
Refactor the filesystem operations to use the asynchronous VS Code workspace API instead of the synchronous node 'fs' module. This prevents blocking the extension host process during file existence checks and template loading.

Key changes:
- Update extension.ts to use vscode.workspace.fs.stat for file size checks.
- Update webview generators to use vscode.workspace.fs.readFile for templates.
- Remove duplicate JSDoc comments in EditorUtils.ts.
- Remove unused 'fs' imports.