### PR TITLE
ui(adb): add Chrome Inspect support in device tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -681,6 +681,11 @@
         "key": "z",
         "when": "focusedView == logmagnifier-shell-commander && !inputFocus",
         "args": "z"
+      },
+      {
+        "command": "logmagnifier.openChromeInspect",
+        "key": "space",
+        "when": "focusedView == logmagnifier-adb-devices && logmagnifier.chromeInspectSelected"
       }
     ],
     "commands": [
@@ -1307,6 +1312,11 @@
         "icon": "$(check)"
       },
       {
+        "command": "logmagnifier.openChromeInspect",
+        "title": "Open Chrome Inspect",
+        "icon": "$(play)"
+      },
+      {
         "command": "logmagnifier.removeMatchesWithSelection",
         "title": "Remove Lines Matching Selection",
         "icon": "$(trash)"
@@ -1603,6 +1613,11 @@
         }
       ],
       "view/item/context": [
+        {
+          "command": "logmagnifier.openChromeInspect",
+          "when": "view == logmagnifier-adb-devices && viewItem == chromeInspect",
+          "group": "inline@1"
+        },
         {
           "command": "logmagnifier.previousMatch",
           "when": "(view == logmagnifier-filters || view == logmagnifier-regex-filters) && viewItem =~ /filterItem.*/",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -136,6 +136,7 @@ export const Constants = {
         ControlStartScreenRecord: 'logmagnifier.control.startScreenRecord',
         ControlStopScreenRecord: 'logmagnifier.control.stopScreenRecord',
         ControlToggleShowTouches: 'logmagnifier.control.toggleShowTouches',
+        OpenChromeInspect: 'logmagnifier.openChromeInspect',
         ClearAllData: 'logmagnifier.clearAllData',
 
         // Bookmark

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,8 +127,12 @@ export function activate(context: vscode.ExtensionContext) {
     const adbService = new AdbService(logger);
     context.subscriptions.push(adbService);
     const adbDeviceTreeProvider = new AdbDeviceTreeProvider(adbService);
-    vscode.window.registerTreeDataProvider(Constants.Views.ADBDevices, adbDeviceTreeProvider);
-    new AdbCommandManager(context, adbService, adbDeviceTreeProvider);
+    // vscode.window.registerTreeDataProvider(Constants.Views.ADBDevices, adbDeviceTreeProvider);
+    const adbTreeView = vscode.window.createTreeView(Constants.Views.ADBDevices, {
+        treeDataProvider: adbDeviceTreeProvider,
+        showCollapseAll: true
+    });
+    new AdbCommandManager(context, adbService, adbDeviceTreeProvider, adbTreeView);
 
     // Shell Commander
     const shellCommanderService = new ShellCommanderService(context);

--- a/src/models/AdbModels.ts
+++ b/src/models/AdbModels.ts
@@ -78,9 +78,14 @@ export interface ControlDeviceActionItem {
     meta?: Record<string, string>;
 }
 
+export interface ChromeInspectItem {
+    type: 'chromeInspect';
+    device?: AdbDevice;
+}
+
 export interface MessageItem {
     type: 'message';
     message: string;
 }
 
-export type AdbTreeItem = AdbDevice | LogcatSession | LogcatTag | TargetAppItem | SessionGroupItem | ControlAppItem | ControlActionItem | DumpsysGroupItem | ControlDeviceItem | ControlDeviceActionItem | MessageItem;
+export type AdbTreeItem = AdbDevice | LogcatSession | LogcatTag | TargetAppItem | SessionGroupItem | ControlAppItem | ControlActionItem | DumpsysGroupItem | ControlDeviceItem | ControlDeviceActionItem | ChromeInspectItem | MessageItem;


### PR DESCRIPTION
Add a new 'Chrome Inspect' item to the ADB device tree view.
This allows users to quickly open the chrome://inspect page for debugging webviews
on connected Android devices. The item uses the 'vm-running' icon for better
visibility and context.