### PR TITLE
agent: enforce --no-pager for git log and git diff

### DIFF
--- a/.agent/rules/git.md
+++ b/.agent/rules/git.md
@@ -1,0 +1,24 @@
+---
+trigger: always_on
+---
+
+# Git Command Guidelines
+
+To prevent terminal hangs and ensure smooth execution in automated or agentic environments, follow these rules when using `git log` and `git diff`.
+
+## Rules
+
+### Use --no-pager
+Always use the `--no-pager` option when executing `git log` or `git diff` commands. This prevents the command from waiting for interactive user input when the output exceeds the terminal height.
+
+**Good:**
+```bash
+git --no-pager log -n 10
+git --no-pager diff
+```
+
+**Bad:**
+```bash
+git log -n 10
+git diff
+```


### PR DESCRIPTION
Add a rule to prevent terminal hangs caused by interactive pagers during git operations.

Using `git log` or `git diff` without `--no-pager` can cause the agent to wait indefinitely for user input if the output exceeds the terminal height. This change ensures that both commands are always executed with the `--no-pager` flag.