### PR TITLE
security: replace insecure CSP nonce generation

### DIFF
--- a/src/utils/WebviewUtils.ts
+++ b/src/utils/WebviewUtils.ts
@@ -1,8 +1,5 @@
+import * as crypto from 'crypto';
+
 export function getNonce(): string {
-    let text = '';
-    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    for (let i = 0; i < 32; i++) {
-        text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
+    return crypto.randomBytes(16).toString('base64');
 }


### PR DESCRIPTION
Replace Math.random() with crypto.randomBytes() for CSP nonces.

Math.random() is not cryptographically secure and weakens the Content Security Policy's ability to prevent XSS attacks.

(Address Code Review Report Item 2.1)