### PR TITLE
security: sanitize webview HTML interpolation

### DIFF
--- a/src/utils/WebviewUtils.ts
+++ b/src/utils/WebviewUtils.ts
@@ -6,3 +6,13 @@ export function getNonce(): string {
     }
     return text;
 }
+
+export function escapeHtml(unsafe: string | undefined | null): string {
+    if (!unsafe) { return ''; }
+    return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}

--- a/src/views/JsonTreeHtmlGenerator.ts
+++ b/src/views/JsonTreeHtmlGenerator.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 import * as path from 'path';
-import { getNonce } from '../utils/WebviewUtils';
+import { getNonce, escapeHtml } from '../utils/WebviewUtils';
 
 export class JsonTreeHtmlGenerator {
     constructor(private readonly context: vscode.ExtensionContext) { }
@@ -25,7 +25,7 @@ export class JsonTreeHtmlGenerator {
             html = new TextDecoder('utf-8').decode(templateBytes);
         } catch (err) {
             console.error('Failed to read JSON Tree template:', err);
-            return `<html><body>Failed to load template. Error: ${err}</body></html>`;
+            return `<html><body>Failed to load template. Error: ${escapeHtml(String(err))}</body></html>`;
         }
 
         const safeJson = (val: unknown) => JSON.stringify(val).replace(/</g, '\\u003c');

--- a/src/views/LogBookmarkWebviewProvider.ts
+++ b/src/views/LogBookmarkWebviewProvider.ts
@@ -5,6 +5,7 @@ import { BookmarkWebviewMessage, SerializedBookmarkItem } from '../models/Webvie
 import { Constants } from '../constants';
 import { Logger } from '../services/Logger';
 import { LogBookmarkHtmlGenerator } from './LogBookmarkHtmlGenerator';
+import { escapeHtml } from '../utils/WebviewUtils';
 
 export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
     private _view?: vscode.WebviewView;
@@ -172,7 +173,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
         } catch (e) {
             this._logger.error(`Error resolving webview view: ${e}`);
             webviewView.webview.html = `<html><body><div style="padding: 20px; color: var(--vscode-errorForeground);">
-                Critical Error resolving view: ${e}
+                Critical Error resolving view: ${escapeHtml(String(e))}
             </div></body></html>`;
         }
     }
@@ -273,7 +274,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider {
                 this._view.webview.html = html;
             } catch (e) {
                 this._view.webview.html = `<html><body><div style="padding: 20px; color: var(--vscode-errorForeground);">
-                    Error loading bookmarks: ${e}<br/>
+                    Error loading bookmarks: ${escapeHtml(String(e))}<br/>
                 </div></body></html>`;
             }
         }, 100);

--- a/src/views/SidebarWorkflowWebviewProvider.ts
+++ b/src/views/SidebarWorkflowWebviewProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { WorkflowManager, WorkflowViewModel } from '../services/WorkflowManager';
+import { escapeHtml } from '../utils/WebviewUtils';
 
 export class SidebarWorkflowWebviewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'logmagnifier-workflow';
@@ -163,7 +164,7 @@ export class SidebarWorkflowWebviewProvider implements vscode.WebviewViewProvide
 
         } catch (e) {
             console.error('Error resolving workflow webview:', e);
-            webviewView.webview.html = `<html><body><div style="padding: 10px;">Error loading workflow view.</div></body></html>`;
+            webviewView.webview.html = `<html><body><div style="padding: 10px;">Error loading workflow view: ${escapeHtml(String(e))}</div></body></html>`;
         }
     }
 
@@ -448,10 +449,10 @@ export class SidebarWorkflowWebviewProvider implements vscode.WebviewViewProvide
             <script>
                 const vscode = acquireVsCodeApi();
                 const container = document.getElementById('graph-container');
-                let workflows = ${JSON.stringify(workflows)};
-                let activeId = "${activeId || ''}";
-                let activeStepId = "${this._workflowManager.getActiveStep() || ''}"; // Note: using direct injection here might be cleaner
-                const colors = ${JSON.stringify(graphColors)};
+                let workflows = ${JSON.stringify(workflows).replace(/</g, '\\u003c')};
+                let activeId = ${JSON.stringify(activeId || '')}.replace(/</g, '\\u003c');
+                let activeStepId = ${JSON.stringify(this._workflowManager.getActiveStep() || '')}.replace(/</g, '\\u003c');
+                const colors = ${JSON.stringify(graphColors).replace(/</g, '\\u003c')};
 
                 // Icons (VS Code Codicons)
                 const icons = {


### PR DESCRIPTION
Escape user-controlled data in webview HTML generators to prevent XSS.

The previous implementation interpolated raw strings into HTML templates, allowing potential script injection via malformed filenames, bookmarks, or workflow names. This change introduces an escapeHtml utility and applies it to all dynamic content in JsonTree, LogBookmark, and Workflow views.

(Address Code Review Report Item 2.2)