### PR TITLE
feat(filter): refine filter execution logic and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -716,6 +716,11 @@
         "icon": "$(plus)"
       },
       {
+        "command": "logmagnifier.runFilterGroup",
+        "title": "Run Filter Group",
+        "icon": "$(play)"
+      },
+      {
         "command": "logmagnifier.addRegexFilter",
         "title": "Add Regex Filter",
         "icon": "$(plus)"
@@ -1819,6 +1824,16 @@
           "command": "logmagnifier.deleteGroup",
           "when": "viewItem =~ /filterGroup.*/ && (view == logmagnifier-filters || view == logmagnifier-regex-filters)",
           "group": "3_edit@2"
+        },
+        {
+          "command": "logmagnifier.runFilterGroup",
+          "when": "view == logmagnifier-filters && viewItem =~ /filterGroup.*/",
+          "group": "inline@9"
+        },
+        {
+          "command": "logmagnifier.runFilterGroup",
+          "when": "view == logmagnifier-regex-filters && viewItem =~ /filterGroup.*/",
+          "group": "inline@9"
         },
         {
           "command": "logmagnifier.addFilter",

--- a/src/test/commands/FilterExecution.test.ts
+++ b/src/test/commands/FilterExecution.test.ts
@@ -1,0 +1,173 @@
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { FilterExecutionCommandManager } from '../../commands/FilterExecutionCommandManager';
+import { FilterManager } from '../../services/FilterManager';
+import { LogProcessor } from '../../services/LogProcessor';
+import { Logger } from '../../services/Logger';
+import { HighlightService } from '../../services/HighlightService';
+import { SourceMapService } from '../../services/SourceMapService';
+import { MockExtensionContext } from '../utils/Mocks';
+import { FilterGroup, FilterItem } from '../../models/Filter';
+
+// Mock LogProcessor to capture processed groups without real file I/O
+class MockLogProcessor extends LogProcessor {
+    public lastProcessedGroups: FilterGroup[] = [];
+
+    constructor() {
+        super();
+    }
+
+    public async processFile(_filePath: string, activeGroups: FilterGroup[], _options?: unknown): Promise<{ matched: number, processed: number, outputPath: string, lineMapping: number[] }> {
+        this.lastProcessedGroups = activeGroups;
+        return { matched: 0, processed: 0, outputPath: '/tmp/output.log', lineMapping: [] };
+    }
+}
+
+// Mock FilterManager to setup test scenarios
+class MockFilterManager extends FilterManager {
+    constructor() {
+        super(new MockExtensionContext());
+        // Clear all initial groups
+        const groups = this.getGroups();
+        [...groups].forEach(g => this.removeGroup(g.id));
+    }
+}
+
+suite('FilterExecutionCommandManager Test Suite', () => {
+    let filterManager: MockFilterManager;
+    let logProcessor: MockLogProcessor;
+    let commandManager: FilterExecutionCommandManager;
+    let mockContext: MockExtensionContext;
+
+    setup(async () => {
+        mockContext = new MockExtensionContext();
+        filterManager = new MockFilterManager();
+        logProcessor = new MockLogProcessor();
+
+        // Mocks for others
+        const logger = Logger.getInstance();
+        const highlightService = new HighlightService(filterManager, logger);
+        const sourceMapService = SourceMapService.getInstance();
+
+        // Mock TreeViews (casted as any to avoid complex mocking of TreeView)
+        const wordTreeView = {} as vscode.TreeView<FilterGroup | FilterItem>;
+        const regexTreeView = {} as vscode.TreeView<FilterGroup | FilterItem>;
+
+        commandManager = new FilterExecutionCommandManager(
+            mockContext,
+            filterManager,
+            highlightService,
+            logProcessor,
+            logger,
+            sourceMapService,
+            wordTreeView,
+            regexTreeView,
+            false // Do not register commands
+        );
+
+        // Open a dummy document so applyFilter proceeds
+        const doc = await vscode.workspace.openTextDocument({ content: 'test log\nERROR test', language: 'log' });
+        await vscode.window.showTextDocument(doc);
+    });
+
+    test('Apply Word Filter (Global) - Group Enablement', async () => {
+        // Scenario:
+        // Group 1: Disabled, Contains Enabled Item
+        // Group 2: Enabled, Contains Disabled Item (no enabled items)
+        // Group 3: Enabled, Contains Enabled Item
+        // Expected:
+        // Group 1 is IGNORED (because Group is disabled)
+        // Group 2 is IGNORED (because no enabled items - Strict Item)
+        // Group 3 is PROCESSED
+
+        const g1 = filterManager.addGroup('Group 1', false)!;
+        // Group 1 Disabled by default? verify addGroup(..., false) -> isRegex=false. isEnabled default false?
+        // Let's explicitly set states.
+        if (g1.isEnabled) { filterManager.toggleGroup(g1.id); }
+        assert.strictEqual(g1.isEnabled, false, 'Group 1 should be disabled');
+        filterManager.addFilter(g1.id, 'Item 1', 'include'); // Default enabled
+
+        const g2 = filterManager.addGroup('Group 2', false)!;
+        if (!g2.isEnabled) { filterManager.toggleGroup(g2.id); } // Enable Group 2
+        const f2 = filterManager.addFilter(g2.id, 'Item 2', 'include')!;
+        filterManager.toggleFilter(g2.id, f2.id); // Disable Item 2
+
+        const g3 = filterManager.addGroup('Group 3', false)!;
+        if (!g3.isEnabled) { filterManager.toggleGroup(g3.id); } // Enable Group 3
+        filterManager.addFilter(g3.id, 'Item 3', 'include'); // Default enabled
+
+        // Access private method by casting to any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (commandManager as any).applyFilter('word');
+
+        const processed = logProcessor.lastProcessedGroups;
+
+        // Verification
+        // Group 1: Ignored (Disabled Group)
+        const g1Processed = processed.find(g => g.id === g1.id);
+        assert.strictEqual(g1Processed, undefined, 'Group 1 should be ignored because group is disabled');
+
+        // Group 2: Ignored (No Enabled Items)
+        const g2Processed = processed.find(g => g.id === g2.id);
+        assert.strictEqual(g2Processed, undefined, 'Group 2 should be ignored because it has no enabled items');
+
+        // Group 3: Processed
+        const g3Processed = processed.find(g => g.id === g3.id);
+        assert.ok(g3Processed, 'Group 3 should be processed');
+    });
+
+    test('Run Filter Group (Specific) - Runs ONLY the target group', async () => {
+        // Scenario:
+        // Group 1: Enabled, Item Enabled
+        // Group 2: Enabled, Item Enabled
+        // Target: Group 1
+        // Expected: Only Group 1 is processed.
+
+        const g1 = filterManager.addGroup('Group 1', false)!;
+        filterManager.toggleGroup(g1.id);
+        filterManager.addFilter(g1.id, 'Item 1', 'include');
+
+        const g2 = filterManager.addGroup('Group 2', false)!;
+        filterManager.toggleGroup(g2.id);
+        filterManager.addFilter(g2.id, 'Item 2', 'include');
+
+        // Execute for Group 1 only
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (commandManager as any).applyFilter('word', g1);
+
+        const processed = logProcessor.lastProcessedGroups;
+
+        assert.strictEqual(processed.length, 1, 'Should process exactly 1 group');
+        assert.strictEqual(processed[0].id, g1.id, 'Should process Group 1');
+    });
+
+    test('Apply Word Filter (Global) - Warning Check', async () => {
+        // Scenario:
+        // No groups added.
+        // Expected: Warning message "No active word groups selected."
+
+        // Mock vscode.window.showWarningMessage
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const originalShowWarningMessage = (vscode.window as any).showWarningMessage;
+        let capturedMessage: string | undefined;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (vscode.window as any).showWarningMessage = async (message: string, ..._items: any[]) => {
+            capturedMessage = message;
+            return undefined;
+        };
+
+        try {
+            // Apply filter with no groups
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            await (commandManager as any).applyFilter('word');
+
+            assert.strictEqual(capturedMessage, 'No active word groups selected.');
+        } finally {
+            // Restore original method
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+        }
+    });
+});


### PR DESCRIPTION
Refactor filter application logic to enforce strict item enablement and
respect group enabled state during global execution.

Key Changes:
- Apply Word Filter (Global): Now ignores disabled groups, even if they
  contain enabled items.
- Run Filter Group (Specific): Executes the target group regardless of its
  enabled state, applying only its enabled items.
- Strict Item Logic: Only explicitly enabled items are included in any
  filter operation.

Technical Details:
- FilterExecutionCommandManager: Updated 'applyFilter' to filter active
  groups based on context (global vs specific). Added 'registerCommands'
  constructor parameter for testability.
- LogProcessor: Simplified 'compileGroups' to process all passed groups.
- Verified with new integration tests in 'FilterExecution.test.ts'
  covering global apply, specific run, and warning messages.