### PR TITLE
ui: add recursive delete action to file hierarchy quick pick

### DIFF
--- a/src/commands/NavigationCommandManager.ts
+++ b/src/commands/NavigationCommandManager.ts
@@ -5,7 +5,13 @@ import { Constants } from '../constants';
 import { FileHierarchyService } from '../services/FileHierarchyService';
 import { Logger } from '../services/Logger';
 
+interface HierarchyQuickPickItem extends vscode.QuickPickItem {
+    _uri: vscode.Uri;
+    _type: 'original' | 'filter' | 'bookmark';
+}
+
 export class NavigationCommandManager {
+
     constructor(
         private context: vscode.ExtensionContext,
         private hierarchyService: FileHierarchyService
@@ -44,79 +50,110 @@ export class NavigationCommandManager {
     }
 
     private async showQuickPick(currentUri: vscode.Uri, _mode: 'siblings' | 'children' | 'tree') {
-        const root = this.hierarchyService.getRoot(currentUri) || currentUri;
-        const items: vscode.QuickPickItem[] = [];
+        const picker = vscode.window.createQuickPick<HierarchyQuickPickItem>();
+        picker.placeholder = 'Navigate File Hierarchy';
+        picker.matchOnDescription = true;
+        picker.matchOnDetail = true;
 
-        // Recursive function to build tree
-        const visited = new Set<string>();
-        const buildTree = (uri: vscode.Uri, depth: number) => {
-            const uriString = uri.toString();
-            if (visited.has(uriString)) {
-                return;
-            }
-            visited.add(uriString);
+        const updateItems = () => {
+            const root = this.hierarchyService.getRoot(currentUri) || currentUri;
+            const items: HierarchyQuickPickItem[] = [];
 
-            const node = this.hierarchyService.getNode(uri);
-            if (!node) { return; }
+            // Recursive function to build tree
+            const buildTree = (uri: vscode.Uri, depth: number) => {
+                const node = this.hierarchyService.getNode(uri);
+                if (!node) { return; }
 
-            const isCurrent = uri.toString() === currentUri.toString();
+                const isCurrent = uri.toString() === currentUri.toString();
 
-            // Indentation
-            const indent = '\u00A0\u00A0\u00A0'.repeat(depth);
-            let icon = '$(file)';
-            if (node.type === 'original') { icon = '$(home)'; }
-            else if (node.type === 'bookmark') { icon = '$(bookmark)'; }
-            else if (node.type === 'filter') { icon = '$(filter)'; }
+                // Indentation
+                // Use figure space for better alignment in Quick Pick
+                const indent = '\u2007\u2007'.repeat(depth);
+                let icon = '$(file)';
+                if (node.type === 'original') { icon = '$(home)'; }
+                else if (node.type === 'bookmark') { icon = '$(bookmark)'; }
+                else if (node.type === 'filter') { icon = '$(filter)'; }
 
-            const label = `${indent}${icon} ${node.label}`;
+                const label = `${indent}${icon} ${node.label}`;
 
-            const item: vscode.QuickPickItem = {
-                label: label,
-                description: isCurrent ? '(Current)' : '',
-                detail: uri.scheme === 'file' ? uri.fsPath : uri.toString(),
-                picked: isCurrent
+                const item: HierarchyQuickPickItem = {
+                    label: label,
+                    description: isCurrent ? '(Current)' : '',
+                    detail: uri.scheme === 'file' ? uri.fsPath : uri.toString(),
+                    picked: isCurrent,
+                    buttons: [
+                        {
+                            iconPath: new vscode.ThemeIcon('trash'),
+                            tooltip: node.type === 'original' ? 'Delete this and all children' : 'Delete this item'
+                        }
+                    ],
+                    _uri: uri,
+                    _type: node.type
+                };
+
+                items.push(item);
+
+                const children = this.hierarchyService.getChildren(uri);
+                // Sort children
+                children.sort((a, b) => {
+                    const nodeA = this.hierarchyService.getNode(a);
+                    const nodeB = this.hierarchyService.getNode(b);
+
+                    return (nodeA?.label || '').localeCompare(nodeB?.label || '');
+                });
+
+                for (const child of children) {
+                    buildTree(child, depth + 1);
+                }
             };
 
-            items.push(item);
+            buildTree(root, 0);
 
-            const children = this.hierarchyService.getChildren(uri);
-            // Sort children
-            children.sort((a, b) => {
-                const nodeA = this.hierarchyService.getNode(a);
-                const nodeB = this.hierarchyService.getNode(b);
-                return (nodeA?.label || '').localeCompare(nodeB?.label || '');
-            });
-
-            for (const child of children) {
-                buildTree(child, depth + 1);
+            if (items.length === 0) {
+                picker.dispose();
+                vscode.window.showInformationMessage('No hierarchy found.');
+                return;
             }
+
+            picker.items = items;
         };
 
-        buildTree(root, 0);
+        updateItems();
 
-        if (items.length === 0) {
-            vscode.window.showInformationMessage(Constants.Messages.Info.NoHierarchyFound);
-            return;
-        }
+        picker.onDidTriggerItemButton(e => {
+            const item = e.item;
+            const uri = item._uri;
+            const type = item._type;
 
-        const selection = await vscode.window.showQuickPick(items, {
-            placeHolder: 'Navigate File Hierarchy',
-            matchOnDescription: true,
-            matchOnDetail: true
+            if (uri) {
+                const isRecursive = type === 'original';
+                this.hierarchyService.unregister(uri, isRecursive);
+                updateItems();
+            }
         });
 
-        if (selection && selection.detail) {
-            let targetUri: vscode.Uri | undefined;
+        picker.onDidAccept(() => {
+            const selection = picker.selectedItems[0];
+            if (selection && selection.detail) {
+                let targetUri: vscode.Uri | undefined;
 
-            if (selection.detail.startsWith('Untitled:') || selection.detail.startsWith('untitled:')) {
-                targetUri = vscode.Uri.parse(selection.detail);
-            } else {
-                targetUri = vscode.Uri.file(selection.detail);
-            }
+                if (selection.detail.startsWith('Untitled:') || selection.detail.startsWith('untitled:')) {
+                    targetUri = vscode.Uri.parse(selection.detail);
+                } else {
+                    targetUri = vscode.Uri.file(selection.detail);
+                }
 
-            if (targetUri) {
-                this.openFile(targetUri);
+                if (targetUri) {
+                    this.openFile(targetUri);
+                }
             }
-        }
+            picker.dispose();
+        });
+
+        picker.onDidHide(() => {
+            picker.dispose();
+        });
+
+        picker.show();
     }
 }


### PR DESCRIPTION
Implement a delete action in the File Hierarchy Quick Pick menu, allowing users to remove items directly from the list.

- Add a "Trash" icon button to each item in the Quick Pick.
- Implement recursive deletion: deleting an "Original" (root) file removes it and all its associated children (filters, bookmarks).
- Implement single item deletion for child nodes (filters), preserving the parent structure.
- Refactor `showQuickPick` to use `vscode.window.createQuickPick` to support item buttons and dynamic updates.