### PR TITLE
security: add CSP nonce to workflow webview

### DIFF
--- a/resources/webview/workflow-tree-template.html
+++ b/resources/webview/workflow-tree-template.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy"
+        content="default-src 'none'; style-src {{CSP_SOURCE}} 'unsafe-inline'; script-src 'nonce-{{NONCE}}';">
     <title>Workflows</title>
     <style>
         body {
@@ -247,7 +249,7 @@
         <div class="menu-item" id="menu-close-all">Close All Results</div>
     </div>
 
-    <script>
+    <script nonce="{{NONCE}}">
         const vscode = acquireVsCodeApi();
         const container = document.getElementById('graph-container');
         let workflows = {{ WORKFLOWS }};

--- a/src/views/WorkflowHtmlGenerator.ts
+++ b/src/views/WorkflowHtmlGenerator.ts
@@ -1,12 +1,13 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { WorkflowViewModel } from '../services/WorkflowManager';
-import { escapeHtml } from '../utils/WebviewUtils';
+import { escapeHtml, getNonce } from '../utils/WebviewUtils';
 
 export class WorkflowHtmlGenerator {
     constructor(private readonly context: vscode.ExtensionContext) { }
 
     public async generate(
+        webview: vscode.Webview,
         workflows: WorkflowViewModel[],
         activeId: string | undefined,
         activeStepId: string | undefined
@@ -33,6 +34,10 @@ export class WorkflowHtmlGenerator {
             'var(--vscode-charts-orange)',
             'var(--vscode-charts-purple)'
         ];
+
+        const nonce = getNonce();
+        html = html.replace(/{{\s*CSP_SOURCE\s*}}/g, webview.cspSource);
+        html = html.replace(/{{\s*NONCE\s*}}/g, nonce);
 
         const safeJson = (val: unknown) => JSON.stringify(val).replace(/</g, '\\u003c');
 

--- a/src/views/WorkflowWebviewProvider.ts
+++ b/src/views/WorkflowWebviewProvider.ts
@@ -36,7 +36,7 @@ export class WorkflowWebviewProvider implements vscode.WebviewViewProvider {
             const activeId = this._workflowManager.getActiveWorkflow();
             const activeStepId = this._workflowManager.getActiveStep();
 
-            webviewView.webview.html = await this.htmlGenerator.generate(workflows, activeId, activeStepId);
+            webviewView.webview.html = await this.htmlGenerator.generate(webviewView.webview, workflows, activeId, activeStepId);
 
             webviewView.webview.onDidReceiveMessage(async (data) => {
                 switch (data.type) {


### PR DESCRIPTION
The workflow webview template was missing a Content-Security-Policy meta tag and nonce attribute on its script tag, unlike the other two webview templates (json-tree, log-bookmark) which already enforce nonce-based script-src.

Add the CSP meta tag and nonce placeholder to the template, pass the webview instance into the HTML generator for cspSource access, and generate a cryptographic nonce per render cycle.