### PR TITLE
shell-commander: unify action handling and add configurable execute s…

### DIFF
--- a/package.json
+++ b/package.json
@@ -500,14 +500,16 @@
         "when": "editorTextFocus && editorHasSelection"
       },
       {
-        "command": "logmagnifier.executeShellCommand",
+        "command": "logmagnifier.shellCommander.handleKey",
         "key": "enter",
-        "when": "focusedView == logmagnifier-shell-commander && viewItem == shellCommand"
+        "when": "focusedView == logmagnifier-shell-commander && !inputFocus",
+        "args": "enter"
       },
       {
-        "command": "logmagnifier.executeShellCommand",
+        "command": "logmagnifier.shellCommander.handleKey",
         "key": "space",
-        "when": "focusedView == logmagnifier-shell-commander && viewItem == shellCommand"
+        "when": "focusedView == logmagnifier-shell-commander && !inputFocus",
+        "args": "space"
       },
       {
         "command": "logmagnifier.applyJsonPretty",
@@ -1066,8 +1068,9 @@
       },
       {
         "command": "logmagnifier.executeShellCommand",
-        "title": "Run Command",
-        "icon": "$(play)"
+        "title": "Execute Command",
+        "icon": "$(play)",
+        "category": "LogMagnifier"
       },
       {
         "command": "logmagnifier.editShellItem",
@@ -1994,8 +1997,8 @@
         },
         {
           "command": "logmagnifier.executeShellCommand",
-          "when": "view == logmagnifier-shell-commander && viewItem == shellCommand",
-          "group": "1_execution"
+          "when": "viewItem == shellCommand",
+          "group": "inline"
         },
         {
           "command": "logmagnifier.addShellCommand",

--- a/src/models/ShellCommander.ts
+++ b/src/models/ShellCommander.ts
@@ -47,6 +47,7 @@ export interface ShellShortCutKeymap {
     kbDelete?: string;
     kbEdit?: string;
     kbView?: string;
+    kbExecuteCommand?: string;
 }
 
 export interface ShellFolderConfig {

--- a/src/services/ShellCommanderService.ts
+++ b/src/services/ShellCommanderService.ts
@@ -17,7 +17,8 @@ export class ShellCommanderService {
         kbCreateCommand: 'c',
         kbDelete: 'd',
         kbEdit: 'e',
-        kbView: 'i'
+        kbView: 'i',
+        kbExecuteCommand: 'space'
     };
 
     constructor(private context: vscode.ExtensionContext) {
@@ -40,8 +41,8 @@ export class ShellCommanderService {
     }
 
     public getKeymap(): ShellShortCutKeymap | undefined {
-        // Return global keymap if loaded, otherwise default
-        return this._globalKeymap || this.DEFAULT_KEYMAP;
+        // Return global keymap merged with default to ensure new keys exist
+        return { ...this.DEFAULT_KEYMAP, ...this._globalKeymap };
     }
 
     public isConfigRegistered(filePath: string): boolean {

--- a/src/test/views/ShellCommanderTreeDataProvider.test.ts
+++ b/src/test/views/ShellCommanderTreeDataProvider.test.ts
@@ -101,7 +101,7 @@ suite('ShellCommanderTreeDataProvider Test Suite', () => {
         assert.strictEqual(item.label, 'Tree Command');
         assert.strictEqual(item.collapsibleState, vscode.TreeItemCollapsibleState.None);
         assert.strictEqual(item.contextValue, 'shellCommand');
-        assert.strictEqual(item.command?.title, 'Execute Command');
+        assert.strictEqual(item.command?.title, 'Show Command');
     });
 
     test('getParent returns correct parent', async () => {

--- a/src/views/ShellCommanderTreeDataProvider.ts
+++ b/src/views/ShellCommanderTreeDataProvider.ts
@@ -75,9 +75,9 @@ export class ShellCommanderTreeDataProvider implements vscode.TreeDataProvider<S
         treeItem.tooltip = new vscode.MarkdownString(`**${command.label}**\n\n\`\`\`sh\n${tooltipScript}\n\`\`\``);
 
         treeItem.command = {
-            command: Constants.Commands.ExecuteShellCommand,
-            title: 'Execute Command',
-            arguments: [command]
+            command: Constants.Commands.HandleShellKey,
+            title: 'Show Command',
+            arguments: ['enter']
         };
 
         return treeItem;


### PR DESCRIPTION
Refactor Shell Commander to move away from multiple command registrations in favor of a unified handleShellKey method for both keyboard shortcuts and tree item click actions.

- Remove redundant logmagnifier.shellCommander.showCommand command.
- Add kbExecuteCommand (defaulting to 'space') to the shortcut keymap.
- Update ShellCommanderTreeDataProvider to trigger handleShellKey with the 'enter' argument when a command item is clicked or selected.
- Restore editor opening behavior for command items when triggered via click or Enter.
- Ensure backward compatibility by merging user keymaps with defaults.
- Update tests to reflect the new unified command structure and verify configurable execution shortcuts.