### PR TITLE
adb: refactor legacy AdbService into focused micro-services

### DIFF
--- a/src/models/AdbModels.ts
+++ b/src/models/AdbModels.ts
@@ -46,7 +46,6 @@ export interface SessionGroupItem {
     device: AdbDevice;
 }
 
-
 export interface DumpsysGroupItem {
     type: 'dumpsysGroup';
     device: AdbDevice;

--- a/src/services/AdbService.ts
+++ b/src/services/AdbService.ts
@@ -1,1106 +1,207 @@
 import * as vscode from 'vscode';
-import * as cp from 'child_process';
 import { AdbDevice, LogcatSession, LogcatTag } from '../models/AdbModels';
-import * as crypto from 'crypto';
-import * as os from 'os';
-import * as path from 'path';
-
 import { Logger } from './Logger';
-import { Constants } from '../Constants';
+import { AdbClient } from './adb/AdbClient';
+import { AdbDeviceService } from './adb/AdbDeviceService';
+import { AdbTargetAppService } from './adb/AdbTargetAppService';
+import { AdbLogcatService } from './adb/AdbLogcatService';
 
 export class AdbService implements vscode.Disposable {
-    private sessions: Map<string, LogcatSession> = new Map();
-    private processes: Map<string, cp.ChildProcess> = new Map();
-    private buffers: Map<string, string[]> = new Map();
-    private flushTimers: Map<string, NodeJS.Timeout> = new Map();
-    private recordingProcesses: Map<string, { process: cp.ChildProcess, remotePath: string, pid?: string }> = new Map(); // deviceId -> process info
-    private stoppingDevices: Set<string> = new Set(); // deviceId
+    private client: AdbClient;
+    private deviceService: AdbDeviceService;
+    private targetAppService: AdbTargetAppService;
+    private logcatService: AdbLogcatService;
 
+    // Events need to be aggregated or exposed from sub-services
     private _onDidChangeSessions = new vscode.EventEmitter<void>();
     public readonly onDidChangeSessions = this._onDidChangeSessions.event;
 
-    constructor(private logger: Logger) { }
+    constructor(private logger: Logger) {
+        this.client = new AdbClient(logger);
+        this.deviceService = new AdbDeviceService(logger, this.client);
+        this.targetAppService = new AdbTargetAppService(logger, this.client);
+        this.logcatService = new AdbLogcatService(logger, this.client, this.targetAppService);
 
-    private deviceTargetApps: Map<string, string> = new Map(); // deviceId -> packageName
-    private getAdbPath(): string {
-        return vscode.workspace.getConfiguration(Constants.Configuration.Section).get<string>(Constants.Configuration.Adb.Path) || Constants.Defaults.AdbPath;
+        // Forward events
+        this.logcatService.onDidChangeSessions(() => this._onDidChangeSessions.fire());
+        this.targetAppService.onDidChangeTargetApp(() => this._onDidChangeSessions.fire());
+        this.deviceService.onDidChangeRecordingStatus(() => this._onDidChangeSessions.fire()); // In case recording affects device status display
     }
 
-    private async execAdb(args: string[]): Promise<string> {
-        return new Promise((resolve, reject) => {
-            const adbPath = this.getAdbPath();
-            cp.execFile(adbPath, args, (err, stdout, stderr) => {
-                if (err) {
-                    reject(new Error(`${err.message} (stderr: ${stderr})`));
-                    return;
-                }
-                resolve(stdout);
-            });
-        });
-    }
-
+    // Devices
     public async getDevices(): Promise<AdbDevice[]> {
-        const adbPath = this.getAdbPath();
-        this.logger.info(`[ADB] Executing: ${adbPath} devices -l`);
+        const devices = await this.deviceService.getDevices();
 
-        try {
-            const stdout = await this.execAdb(['devices', '-l']);
-
-            this.logger.info(`[ADB] Raw output:\n${stdout.trim()}`);
-
-            const devices: AdbDevice[] = [];
-            const lines = stdout.split('\n');
-            for (const line of lines) {
-                if (!line.trim() || line.startsWith('List of devices attached')) {
-                    continue;
-                }
-                // Parse line: "serial product:p model:m device:d transport_id:t"
-                const parts = line.split(/\s+/);
-                if (parts.length >= 2) {
-                    const id = parts[0];
-                    const type = parts[1];
-                    const device: AdbDevice = { id, type };
-
-                    for (let i = 2; i < parts.length; i++) {
-                        const [key, value] = parts[i].split(':');
-                        if (key && value) {
-                            if (key === 'transport_id') {
-                                device.transportId = value;
-                            } else if (key === 'product') {
-                                device.product = value;
-                            } else if (key === 'model') {
-                                device.model = value;
-                            } else if (key === 'device') {
-                                device.device = value;
-                            }
-                        }
-                    }
-                    this.logger.info(`[ADB] Parsed device: ${JSON.stringify(device)}`);
-                    devices.push(device);
-                }
-            }
-
-            // Validate Target Apps
-            const validationPromises = devices.map(async (device) => {
-                const storedTarget = this.deviceTargetApps.get(device.id);
-                if (storedTarget && storedTarget !== 'all') {
-                    // Check if running
-                    try {
-                        const runningApps = await this.getRunningApps(device.id);
-                        if (!runningApps.has(storedTarget)) {
-                            this.logger.info(`[ADB] Target app ${storedTarget} not running on ${device.id}. Resetting to all.`);
-                            this.deviceTargetApps.set(device.id, 'all');
-                            device.targetApp = 'all';
-                        } else {
-                            device.targetApp = storedTarget;
-                        }
-                    } catch (_e) {
-                        this.logger.warn(`[ADB] Failed to check running apps for ${device.id}, keeping stored target.`);
-                        device.targetApp = storedTarget;
-                    }
+        // Sync target apps
+        for (const device of devices) {
+            const target = this.targetAppService.getTargetApp(device.id);
+            if (target && target !== 'all') {
+                const running = await this.targetAppService.getRunningApps(device.id);
+                if (running.has(target)) {
+                    device.targetApp = target;
                 } else {
+                    this.logger.info(`[ADB] Target app ${target} not running on ${device.id}. Resetting.`);
+                    this.targetAppService.setTargetApp(device, 'all');
                     device.targetApp = 'all';
                 }
-            });
-
-            await Promise.all(validationPromises);
-            return devices;
-
-        } catch (err: unknown) {
-            const errorMessage = err instanceof Error ? err.message : String(err);
-            this.logger.error(`[ADB] Error running adb devices: ${errorMessage}`);
-            return [];
+            } else {
+                device.targetApp = 'all';
+            }
         }
+        return devices;
     }
 
+    // Target Apps
     public async getInstalledPackages(deviceId: string): Promise<string[]> {
-        const packages = await this.fetchPackages(deviceId);
-        return Array.from(packages).sort();
+        return this.targetAppService.getInstalledPackages(deviceId);
     }
 
     public async getThirdPartyPackages(deviceId: string): Promise<Set<string>> {
-        return this.fetchPackages(deviceId, '-3');
-    }
-
-    private async fetchPackages(deviceId: string, filter: string = ''): Promise<Set<string>> {
-        return new Promise((resolve) => {
-            const adbPath = this.getAdbPath();
-            const filterLog = filter ? ` with filter '${filter}'` : '';
-            this.logger.info(`[ADB] Getting packages for device ${deviceId}${filterLog}...`);
-
-            const args = ['-s', deviceId, 'shell', 'pm', 'list', 'packages'];
-            if (filter) {
-                args.push(filter);
-            }
-
-            cp.execFile(adbPath, args, (err, stdout, _stderr) => {
-                if (err) {
-                    this.logger.error(`[ADB] Error getting packages: ${err.message}`);
-                    resolve(new Set());
-                    return;
-                }
-                const packages = stdout.split('\n')
-                    .filter(line => line.startsWith('package:'))
-                    .map(line => line.replace('package:', '').trim());
-                this.logger.info(`[ADB] Found ${packages.length} packages.`);
-                resolve(new Set(packages));
-            });
-        });
+        return this.targetAppService.getThirdPartyPackages(deviceId);
     }
 
     public async getRunningApps(deviceId: string): Promise<Set<string>> {
-        return new Promise((resolve) => {
-            const adbPath = this.getAdbPath();
-            // ps -A (newer Android) or fallback to ps (older Android)
-            // format: USER PID PPID VSZ RSS WCHAN ADDR S NAME
-            const cmd = `${adbPath} -s ${deviceId} shell ps -A`;
-            this.logger.info(`[ADB] Getting running apps: ${cmd}`);
-
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'ps', '-A'], (err, stdout) => {
-                if (err) {
-                    // Fallback to simple 'ps' if -A fails (older Android)
-                    this.logger.warn(`[ADB] ps -A failed, trying ps: ${err.message}`);
-                    cp.execFile(adbPath, ['-s', deviceId, 'shell', 'ps'], (err2, stdout2) => {
-                        if (err2) {
-                            this.logger.error(`[ADB] Error getting running apps: ${err2.message}`);
-                            resolve(new Set());
-                            return;
-                        }
-                        this.parsePsOutput(stdout2).then(resolve);
-                    });
-                    return;
-                }
-                this.parsePsOutput(stdout).then(resolve);
-            });
-        });
-    }
-
-    private async parsePsOutput(output: string): Promise<Set<string>> {
-        const running = new Set<string>();
-        const lines = output.split('\n');
-        // valid package names usually look like com.example.app, but ps output has many columns.
-        // Standard Android ps: USER PID ... NAME (Last column, but might be space separated arguments if we aren't careful, though usually package name is single token)
-        // However, some ps outputs have 9 columns. Index 8 is NAME.
-        for (const line of lines) {
-            const parts = line.trim().split(/\s+/);
-            if (parts.length >= 9) {
-                // Join everything from index 8 onwards to handle potential spaces (rare for package names but good for safety)
-                const name = parts.slice(8).join(' '); // NAME is usually at index 8
-                if (name && name.includes('.') && !name.startsWith('[')) {
-                    running.add(name);
-                }
-            } else if (parts.length > 0) {
-                // Fallback for non-standard ps or older androids where column count might differ
-                // Just take the last part if it looks like a package
-                const name = parts[parts.length - 1];
-                if (name && name.includes('.') && !name.startsWith('[')) {
-                    running.add(name);
-                }
-            }
-        }
-        return running;
+        return this.targetAppService.getRunningApps(deviceId);
     }
 
     public async getAppPid(deviceId: string, packageName: string): Promise<string | undefined> {
-        return this.findPid(deviceId, packageName);
-    }
-
-    private async findPid(deviceId: string, search: string): Promise<string | undefined> {
-        return new Promise((resolve) => {
-            const adbPath = this.getAdbPath();
-            // Try pidof first (fastest)
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'pidof', '-s', search], (err, stdout) => {
-                if (!err && stdout.trim()) {
-                    resolve(stdout.trim());
-                    return;
-                }
-
-                // Fallback: ps -A (newer) or ps (older)
-                cp.execFile(adbPath, ['-s', deviceId, 'shell', 'ps', '-A'], (err2, stdout2) => {
-                    if (err2) {
-                        // Try simple ps
-                        cp.execFile(adbPath, ['-s', deviceId, 'shell', 'ps'], (err3, stdout3) => {
-                            if (err3) {
-                                resolve(undefined);
-                                return;
-                            }
-                            resolve(this.parsePsForPid(stdout3, search));
-                        });
-                        return;
-                    }
-                    resolve(this.parsePsForPid(stdout2, search));
-                });
-            });
-        });
-    }
-
-    private parsePsForPid(output: string, search: string): string | undefined {
-        const lines = output.split('\n');
-        for (const line of lines) {
-            const parts = line.trim().split(/\s+/);
-            if (parts.length < 9) { continue; }
-            // 2nd column is typically PID in standard Android ps (USER PID ...)
-            const pid = parts[1];
-            // Name starts at index 8
-            const name = parts.slice(8).join(' ');
-
-            if (name === search || name.endsWith(`/${search}`)) {
-                return pid;
-            }
-        }
-        return undefined;
+        return this.targetAppService.getAppPid(deviceId, packageName);
     }
 
     public setTargetApp(device: AdbDevice, packageName: string) {
-        this.deviceTargetApps.set(device.id, packageName);
-        device.targetApp = packageName;
-        this._onDidChangeSessions.fire(); // Refresh tree
-    }
-
-    public createSession(name: string, device: AdbDevice): LogcatSession {
-        const session: LogcatSession = {
-            id: crypto.randomUUID(),
-            name,
-            device,
-            tags: [],
-            isRunning: false,
-            useStartFromCurrentTime: true // Default to true (current behavior with default options)
-        };
-        this.sessions.set(session.id, session);
-        this._onDidChangeSessions.fire();
-        this.logger.info(`[Session] Created session '${name}' for device ${device.id}`);
-        return session;
-    }
-
-    public getSessions(): LogcatSession[] {
-        return Array.from(this.sessions.values());
-    }
-
-    public getSession(id: string): LogcatSession | undefined {
-        return this.sessions.get(id);
-    }
-
-    public removeSession(id: string) {
-        this.stopSession(id);
-        this.sessions.delete(id);
-        this._onDidChangeSessions.fire();
-        this.logger.info(`[Session] Removed session ${id}`);
-    }
-
-    public async startSession(sessionId: string) {
-        const session = this.sessions.get(sessionId);
-        if (!session || session.isRunning) {
-            return;
-        }
-
-        if (session.outputDocumentUri) {
-            const uri = vscode.Uri.parse(session.outputDocumentUri);
-            const doc = vscode.workspace.textDocuments.find(d => d.uri.toString() === uri.toString());
-            // If document is not found or is closed, clear the reference to create a new one
-            if (!doc || doc.isClosed) {
-                session.outputDocumentUri = undefined;
-            }
-        }
-
-        try {
-            const adbPath = this.getAdbPath();
-            const defaultOptions = vscode.workspace.getConfiguration(Constants.Configuration.Section).get<string>(Constants.Configuration.Adb.DefaultOptions) || Constants.Defaults.AdbDefaultOptions;
-
-            // basic args: -s <device> logcat
-            const args = ['-s', session.device.id, 'logcat'];
-
-            // Add default options (split by space)
-            // If useStartFromCurrentTime is false, we filter OUT time flags (-T or -t) from default options.
-            // If true, we ensure -T 1 is present later if not in default options.
-
-            const startFromNow = session.useStartFromCurrentTime !== false; // Default true
-
-            if (defaultOptions.trim().length > 0) {
-                const parts = defaultOptions.split(/\s+/);
-                for (let i = 0; i < parts.length; i++) {
-                    const part = parts[i];
-                    // Check for time flags
-                    if (part === '-T' || part === '-t') {
-                        if (!startFromNow) {
-                            // Skip this and the next argument (the value)
-                            i++;
-                            continue;
-                        }
-                    }
-                    args.push(part);
-                }
-            }
-
-            // If startFromNow is enabled and no time flag (-T or -t) exists in args (from defaultOptions),
-            // force adding '-T 1' to ensure we only show logs from now.
-
-            const hasTimeArg = args.includes('-T') || args.includes('-t');
-            if (startFromNow && !hasTimeArg) {
-                args.push('-T', '1');
-            }
-
-            // PID Filter
-            if (session.device.targetApp && session.device.targetApp !== 'all') {
-                const pid = await this.getAppPid(session.device.id, session.device.targetApp);
-                if (pid) {
-                    this.logger.info(`[ADB] Resolved PID for ${session.device.targetApp}: ${pid}`);
-                    args.push(`--pid=${pid}`);
-                } else {
-                    vscode.window.showWarningMessage(Constants.Messages.Warn.AppNotRunning.replace('{0}', session.device.targetApp));
-                }
-            }
-
-            // Add tag filters (Tag:Priority).
-            // If tags are present, default others to Silent (*:S). Otherwise show all (*:V).
-
-            if (session.tags.length > 0) {
-                session.tags.forEach(tag => {
-                    if (tag.isEnabled) {
-                        args.push(`${tag.name}:${tag.priority}`);
-                    }
-                });
-                // Strictly filter logs based on the tags.
-                args.push('*:S');
-            } else {
-                args.push('*:V');
-            }
-
-            const command = `${adbPath} ${args.join(' ')}`;
-            this.logger.info(`[ADB] Starting logcat: ${command}`);
-
-            const child = cp.spawn(adbPath, args);
-            this.processes.set(sessionId, child);
-            session.isRunning = true;
-            this._onDidChangeSessions.fire();
-
-            // Open document if not already associated
-            if (!session.outputDocumentUri) {
-                const now = new Date();
-                const pad = (n: number) => n.toString().padStart(2, '0');
-                const pad3 = (n: number) => n.toString().padStart(3, '0');
-
-                // UTC
-                const utcStr = `${now.getUTCFullYear()}-${pad(now.getUTCMonth() + 1)}-${pad(now.getUTCDate())} ${pad(now.getUTCHours())}:${pad(now.getUTCMinutes())}:${pad(now.getUTCSeconds())}.${pad3(now.getUTCMilliseconds())}`;
-
-                // Local
-                const off = -now.getTimezoneOffset();
-                const sign = off >= 0 ? '+' : '-';
-                const absOff = Math.abs(off);
-                const offH = Math.floor(absOff / 60);
-                const offM = absOff % 60;
-                const tz = `${sign}${pad(offH)}:${pad(offM)}`;
-                const localStr = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}.${pad3(now.getMilliseconds())} ${tz}`;
-
-                const header = `Logcat session: ${session.name}\n` +
-                    `Command: ${command}\n` +
-                    `Start time\n` +
-                    `- ${localStr}\n` +
-                    `- ${utcStr} +00:00\n` +
-                    `${'='.repeat(80)}\n`;
-                const doc = await vscode.workspace.openTextDocument({ language: 'log', content: header });
-                await vscode.window.showTextDocument(doc, { preview: false, preserveFocus: true });
-                session.outputDocumentUri = doc.uri.toString();
-            }
-
-            // Setup output handling
-            child.stdout.on('data', (data) => {
-                const lines = data.toString().split('\n');
-                this.bufferLogs(sessionId, lines);
-            });
-
-            child.stderr.on('data', (data) => {
-                // Logcat stderr often contains useful info too (like "unexpected EOF")
-                const lines = data.toString().split('\n');
-                this.bufferLogs(sessionId, lines.map((l: string) => `[STDERR] ${l}`));
-            });
-
-            child.on('close', (code) => {
-                this.logger.info(`[ADB] Logcat process exited with code ${code}`);
-                session.isRunning = false;
-                this.processes.delete(sessionId);
-                this._onDidChangeSessions.fire();
-                this.flushLogs(sessionId); // Flush remaining
-            });
-
-            child.on('error', (err) => {
-                this.logger.error(`[ADB] Failed to start logcat process: ${err.message}`);
-                vscode.window.showErrorMessage(Constants.Messages.Error.LogcatStartFailed.replace('{0}', err.message));
-                session.isRunning = false;
-                this._onDidChangeSessions.fire();
-            });
-
-        } catch (error) {
-            this.logger.error(`[ADB] Exception starting logcat: ${error}`);
-            vscode.window.showErrorMessage(Constants.Messages.Error.LogcatStartFailed.replace('{0}', String(error)));
-        }
-    }
-
-    public stopSession(sessionId: string) {
-        const child = this.processes.get(sessionId);
-        if (child) {
-            child.kill();
-            this.processes.delete(sessionId);
-        }
-        const session = this.sessions.get(sessionId);
-        if (session) {
-            session.isRunning = false;
-            this._onDidChangeSessions.fire();
-        }
-        // clear flush timer
-        const timer = this.flushTimers.get(sessionId);
-        if (timer) {
-            clearInterval(timer);
-            this.flushTimers.delete(sessionId);
-        }
-    }
-
-    public addTag(sessionId: string, tag: LogcatTag) {
-        const session = this.sessions.get(sessionId);
-        if (session && !session.isRunning) {
-            session.tags.push(tag);
-            this._onDidChangeSessions.fire();
-        }
-    }
-
-    public removeTag(sessionId: string, tagId: string) {
-        const session = this.sessions.get(sessionId);
-        if (session && !session.isRunning) {
-            session.tags = session.tags.filter(t => t.id !== tagId);
-            this._onDidChangeSessions.fire();
-        }
-    }
-
-    public updateTag(sessionId: string, tag: LogcatTag) {
-        const session = this.sessions.get(sessionId);
-        if (session && !session.isRunning) {
-            const index = session.tags.findIndex(t => t.id === tag.id);
-            if (index !== -1) {
-                session.tags[index] = tag;
-                this._onDidChangeSessions.fire();
-            }
-        }
-    }
-
-    public toggleSessionTimeFilter(sessionId: string) {
-        const session = this.sessions.get(sessionId);
-        if (session && !session.isRunning) {
-            session.useStartFromCurrentTime = !session.useStartFromCurrentTime;
-            this.logger.info(`[Session] Toggled time filter for ${sessionId} to ${session.useStartFromCurrentTime}`);
-            this._onDidChangeSessions.fire();
-        }
-    }
-
-    // Buffering Logic
-    private bufferLogs(sessionId: string, lines: string[]) {
-        const buffer = this.buffers.get(sessionId) || [];
-        // Filter out empty lines if needed
-        const newLines = lines.filter(l => l.length > 0);
-        buffer.push(...newLines);
-        this.buffers.set(sessionId, buffer);
-
-        if (!this.flushTimers.has(sessionId)) {
-            const timer = setInterval(() => this.flushLogs(sessionId), 500); // Flush every 500ms
-            this.flushTimers.set(sessionId, timer);
-        }
-    }
-
-    private async flushLogs(sessionId: string) {
-        const buffer = this.buffers.get(sessionId);
-        if (!buffer || buffer.length === 0) {
-            return;
-        }
-
-        const session = this.sessions.get(sessionId);
-        if (!session || !session.outputDocumentUri) {
-            this.buffers.set(sessionId, []); // Clear buffer if nowhere to write
-            return;
-        }
-
-        const contentToAppend = buffer.join('\n') + '\n';
-        this.buffers.set(sessionId, []); // Clear buffer immediately to capture new logs
-
-        try {
-            const uri = vscode.Uri.parse(session.outputDocumentUri);
-            // We need to find the document. It might be closed.
-            const doc = vscode.workspace.textDocuments.find(d => d.uri.toString() === uri.toString());
-
-            if (doc) {
-                const edit = new vscode.WorkspaceEdit();
-                const lastLine = doc.lineCount;
-                const position = new vscode.Position(lastLine, 0);
-                edit.insert(uri, position, contentToAppend);
-                const success = await vscode.workspace.applyEdit(edit);
-
-                if (success) {
-                    // Auto-scroll
-                    const editor = vscode.window.visibleTextEditors.find(e => e.document.uri.toString() === uri.toString());
-                    if (editor) {
-                        const newLastLine = doc.lineCount - 1;
-                        const newPosition = new vscode.Position(newLastLine, 0);
-                        editor.revealRange(new vscode.Range(newPosition, newPosition), vscode.TextEditorRevealType.Default);
-                    }
-                }
-            } else {
-                // specific behavior if doc is closed? Close session?
-                this.logger.warn('Output document closed, stopping session');
-                this.stopSession(sessionId);
-            }
-        } catch (e) {
-            this.logger.error(`Failed to write to logcat document: ${e}`);
-        }
+        this.targetAppService.setTargetApp(device, packageName);
     }
 
     public async uninstallApp(deviceId: string, packageName: string): Promise<boolean> {
-        return new Promise((resolve) => {
-            const adbPath = this.getAdbPath();
-            this.logger.info(`[ADB] Uninstalling ${packageName} on ${deviceId}`);
-            cp.execFile(adbPath, ['-s', deviceId, 'uninstall', packageName], (err, stdout) => {
-                if (err) {
-                    this.logger.error(`[ADB] Uninstall failed: ${err.message}`);
-                    resolve(false);
-                    return;
-                }
-                this.logger.info(`[ADB] Uninstall output: ${stdout.trim()}`);
-                resolve(stdout.includes('Success'));
-            });
-        });
+        return this.targetAppService.uninstallApp(deviceId, packageName);
     }
 
     public async clearAppStorage(deviceId: string, packageName: string): Promise<boolean> {
-        return new Promise((resolve) => {
-            const adbPath = this.getAdbPath();
-            this.logger.info(`[ADB] Clearing storage for ${packageName} on ${deviceId}`);
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'pm', 'clear', packageName], (err, stdout) => {
-                if (err) {
-                    this.logger.error(`[ADB] Clear storage failed: ${err.message}`);
-                    resolve(false);
-                    return;
-                }
-                this.logger.info(`[ADB] Clear storage output: ${stdout.trim()}`);
-                resolve(stdout.includes('Success'));
-            });
-        });
+        return this.targetAppService.clearAppStorage(deviceId, packageName);
     }
 
     public async clearAppCache(deviceId: string, packageName: string): Promise<boolean> {
-        return new Promise((resolve) => {
-            const adbPath = this.getAdbPath();
-            this.logger.info(`[ADB] Clearing cache for ${packageName} on ${deviceId}`);
-            // Note: This only works for debuggable apps or rooted devices usually via run-as
-            // For non-debuggable apps without root, clearing just cache isn't easily possible via adb without pm clear
-            // But we try nonetheless.
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'run-as', packageName, 'rm', '-rf', 'cache', 'code_cache'], (err, stdout) => {
-                if (err) {
-                    this.logger.warn(`[ADB] Clear cache failed (might need debuggable app): ${err.message}`);
-                    // We interpret 'run-as: package not debuggable' as a sort of failure but we resolve true so UI isn't blocked?
-                    // actually resolve false to maybe warn user?
-                    // Detailed error often in stderr.
-                    resolve(false);
-                    return;
-                }
-                this.logger.info(`[ADB] Clear cache output: ${stdout.trim()}`);
-                resolve(true); // rm -rf usually doesn't output 'Success'
-            });
-        });
+        return this.targetAppService.clearAppCache(deviceId, packageName);
     }
-    public async runDumpsysPackage(deviceId: string, packageName: string): Promise<string> {
-        return new Promise((resolve, reject) => {
-            const adbPath = this.getAdbPath();
-            const cmd = `${adbPath} -s ${deviceId} shell dumpsys package ${packageName}`;
-            this.logger.info(`[ADB] Running dumpsys: ${cmd}`);
 
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'dumpsys', 'package', packageName], { maxBuffer: 1024 * 1024 * 10 }, (err, stdout, _stderr) => {
-                if (err) {
-                    this.logger.error(`[ADB] Dumpsys failed: ${err.message}`);
-                    reject(err);
-                    return;
-                }
-                resolve(stdout);
-            });
-        });
+    public async runDumpsysPackage(deviceId: string, packageName: string): Promise<string> {
+        return this.targetAppService.runDumpsysPackage(deviceId, packageName);
     }
 
     public async runDumpsysMeminfo(deviceId: string, packageName: string): Promise<string> {
-        return new Promise((resolve, reject) => {
-            const adbPath = this.getAdbPath();
-            const cmd = `${adbPath} -s ${deviceId} shell dumpsys meminfo ${packageName}`;
-            this.logger.info(`[ADB] Running dumpsys meminfo: ${cmd}`);
-
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'dumpsys', 'meminfo', packageName], { maxBuffer: 1024 * 1024 * 10 }, (err, stdout, _stderr) => {
-                if (err) {
-                    this.logger.error(`[ADB] Dumpsys meminfo failed: ${err.message}`);
-                    reject(err);
-                    return;
-                }
-                resolve(stdout);
-            });
-        });
+        return this.targetAppService.runDumpsysMeminfo(deviceId, packageName);
     }
 
     public async runDumpsysActivity(deviceId: string, packageName: string): Promise<string> {
-        return new Promise((resolve, reject) => {
-            const adbPath = this.getAdbPath();
-            const cmd = `${adbPath} -s ${deviceId} shell dumpsys activity ${packageName}`;
-            this.logger.info(`[ADB] Running dumpsys activity: ${cmd}`);
-
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'dumpsys', 'activity', packageName], { maxBuffer: 1024 * 1024 * 10 }, (err, stdout, _stderr) => {
-                if (err) {
-                    this.logger.error(`[ADB] Dumpsys activity failed: ${err.message}`);
-                    reject(err);
-                    return;
-                }
-                resolve(stdout);
-            });
-        });
-    }
-
-    public async captureScreenshot(deviceId: string, localOutputPath: string): Promise<boolean> {
-        return new Promise((resolve) => {
-            const adbPath = this.getAdbPath();
-            const remotePath = `/data/local/tmp/vscode_screenshot_${Date.now()}.png`;
-
-            this.logger.info(`[ADB] Capturing screenshot on ${deviceId} to ${remotePath}`);
-
-            // 1. Capture to remote temp file
-            const captureArgs = ['-s', deviceId, 'shell', 'screencap', '-p', remotePath];
-            this.logger.info(`[ADB] Command: ${adbPath} ${captureArgs.join(' ')}`);
-
-            cp.execFile(adbPath, captureArgs, async (err) => {
-                if (err) {
-                    this.logger.error(`[ADB] Screenshot capture failed: ${err.message}`);
-                    resolve(false);
-                    return;
-                }
-
-                // 2. Pull file to local
-                this.logger.info(`[ADB] Pulling screenshot to ${localOutputPath}`);
-                const pullArgs = ['-s', deviceId, 'pull', remotePath, localOutputPath];
-                this.logger.info(`[ADB] Command: ${adbPath} ${pullArgs.join(' ')}`);
-
-                cp.execFile(adbPath, pullArgs, async (pullErr) => {
-                    if (pullErr) {
-                        this.logger.error(`[ADB] Screenshot pull failed: ${pullErr.message}`);
-                        // Try cleanup anyway
-                        const cleanupArgs = ['-s', deviceId, 'shell', 'rm', remotePath];
-                        this.logger.info(`[ADB] Command (cleanup): ${adbPath} ${cleanupArgs.join(' ')}`);
-                        cp.execFile(adbPath, cleanupArgs, (_e) => { /* ignore */ });
-                        resolve(false);
-                        return;
-                    }
-
-                    // 3. Cleanup remote file
-                    this.logger.info(`[ADB] Cleaning up ${remotePath}`);
-                    const cleanupArgs = ['-s', deviceId, 'shell', 'rm', remotePath];
-                    this.logger.info(`[ADB] Command: ${adbPath} ${cleanupArgs.join(' ')}`);
-
-                    cp.execFile(adbPath, cleanupArgs, (cleanErr) => {
-                        if (cleanErr) {
-                            this.logger.warn(`[ADB] Failed to cleanup remote screenshot: ${cleanErr.message}`);
-                        }
-                        resolve(true);
-                    });
-                });
-            });
-        });
-    }
-
-    public isDeviceRecording(deviceId: string): boolean {
-        return this.recordingProcesses.has(deviceId);
-    }
-
-    public isDeviceStopping(deviceId: string): boolean {
-        return this.stoppingDevices.has(deviceId);
-    }
-
-    public async startRecording(deviceId: string): Promise<boolean> {
-        if (this.isDeviceRecording(deviceId) || this.isDeviceStopping(deviceId)) {
-            return false;
-        }
-
-        const adbPath = this.getAdbPath();
-        const timestamp = new Date().getTime();
-        const remotePath = `/data/local/tmp/screenrecord_${timestamp}.mp4`;
-
-        this.logger.info(`[ADB] Starting recording on ${deviceId} to ${remotePath}`);
-
-        const args = ['-s', deviceId, 'shell', 'screenrecord', remotePath];
-        this.logger.info(`[ADB] Spawning (stdio: pipe): ${adbPath} ${args.join(' ')}`);
-
-        // Use 'pipe' for stdout/stderr to capture logs for debugging.
-        // Stdin is ignored to avoid holding the process open unnecessarily if not used.
-        const child = cp.spawn(adbPath, args, { stdio: ['ignore', 'pipe', 'pipe'] });
-
-        if (child.stdout) {
-            child.stdout.on('data', (data) => {
-                this.logger.info(`[ADB][screenrecord] stdout: ${data.toString().trim()}`);
-            });
-        }
-        if (child.stderr) {
-            child.stderr.on('data', (data) => {
-                this.logger.error(`[ADB][screenrecord] stderr: ${data.toString().trim()}`);
-            });
-        }
-
-        child.on('error', (err) => {
-            this.logger.error(`[ADB] Failed to start screenrecord: ${err.message}`);
-            this.recordingProcesses.delete(deviceId);
-            this._onDidChangeSessions.fire();
-            vscode.window.showErrorMessage(Constants.Messages.Error.RecordingFailed.replace('{0}', err.message));
-        });
-
-        child.on('close', async (code) => {
-            this.logger.info(`[ADB] Local adb process closed on ${deviceId} (code ${code})`);
-            this.recordingProcesses.delete(deviceId);
-
-            // Trigger pull regardless of how it stopped (manual stop or limit reached).
-
-            this._onDidChangeSessions.fire();
-
-            // Check file and pull immediately (stabilization check is inside checkAndPullRecording)
-            await this.checkAndPullRecording(deviceId, remotePath);
-
-            // Ensure stopping state is cleared if it was set
-            if (this.stoppingDevices.has(deviceId)) {
-                this.stoppingDevices.delete(deviceId);
-                this._onDidChangeSessions.fire();
-            }
-        });
-
-        // Store process info
-        this.recordingProcesses.set(deviceId, { process: child, remotePath });
-        this._onDidChangeSessions.fire();
-
-        // Find PID
-        setTimeout(async () => {
-            const pid = await this.findPid(deviceId, 'screenrecord');
-            if (pid) {
-                this.logger.info(`[ADB] Remote screenrecord PID: ${pid}`);
-                const info = this.recordingProcesses.get(deviceId);
-                if (info) {
-                    info.pid = pid;
-                }
-            }
-        }, 1000);
-
-        return true;
-    }
-
-    public async stopRecording(deviceId: string): Promise<void> {
-        const info = this.recordingProcesses.get(deviceId);
-        if (!info) {
-            this.logger.warn(`[ADB] No recording session found for ${deviceId}`);
-            return;
-        }
-
-        // Set stopping state to show spinner
-        this.stoppingDevices.add(deviceId);
-        this._onDidChangeSessions.fire();
-
-        this.logger.info(`[ADB] Stopping recording on ${deviceId}`);
-        const adbPath = this.getAdbPath();
-
-        // 1. Send explicit SIGINT to remote process
-        let pid = info.pid;
-        if (!pid) {
-            pid = await this.findPid(deviceId, 'screenrecord');
-        }
-
-        if (pid) {
-            this.logger.info(`[ADB] Sending SIGINT to remote process ${pid}...`);
-
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'kill', '-2', pid], (err) => {
-                if (err) {
-                    this.logger.warn(`[ADB] Failed to kill -2: ${err.message}`);
-                } else {
-                    this.logger.info(`[ADB] Signal sent.`);
-                }
-            });
-            // Removed fixed delay here
-        } else {
-            this.logger.warn(`[ADB] Could not determine remote PID. Stopping local process only.`);
-        }
-
-        // 2. Wait for remote process to die
-        this.logger.info(`[ADB] Waiting for remote screenrecord to finish...`);
-        const maxWait = 5000; // 5 seconds
-        const start = Date.now();
-
-        while (Date.now() - start < maxWait) {
-            const currentPid = await this.findPid(deviceId, 'screenrecord');
-            if (!currentPid) {
-                this.logger.info(`[ADB] Remote screenrecord process gone.`);
-                break;
-            }
-            await new Promise(resolve => setTimeout(resolve, 500));
-        }
-
-        // 3. Kill local process to cleanup
-        if (info.process) {
-            this.logger.info(`[ADB] Killing local adb process...`);
-            info.process.kill();
-        }
-
-        // Cleanup map logic and stopping state clearing is handled in 'close' handler.
-    }
-
-    private async checkAndPullRecording(deviceId: string, remotePath: string): Promise<void> {
-        const adbPath = this.getAdbPath();
-
-        this.logger.info(`[ADB] Checking file status...`);
-        let attempts = 0;
-        const maxAttempts = 10;
-        let previousSize = 0;
-
-        const checkLoop = async () => {
-            while (attempts < maxAttempts) {
-
-                const result = await new Promise<{ size: number, output: string }>((resolve) => {
-                    cp.execFile(adbPath, ['-s', deviceId, 'shell', 'ls', '-l', remotePath], (_err, stdout) => {
-                        attempts++;
-                        let size = 0;
-                        if (stdout) {
-                            const parts = stdout.trim().split(/\s+/);
-                            if (parts.length >= 5) {
-                                size = parseInt(parts[4], 10);
-                            }
-                        }
-                        resolve({ size, output: stdout?.trim() || '' });
-                    });
-                });
-
-                this.logger.info(`[ADB] File size check (${attempts}/${maxAttempts}): ${result.size} bytes`);
-
-                if (result.size > 0 && result.size === previousSize) {
-                    this.logger.info(`[ADB] File size stabilized at ${result.size} bytes`);
-                    await this.pullRecording(deviceId, remotePath);
-                    return;
-                } else if (result.size > 0 && attempts >= maxAttempts) {
-                    this.logger.warn(`[ADB] Max attempts reached. File size: ${result.size} bytes`);
-                    await this.pullRecording(deviceId, remotePath);
-                    return;
-                } else if (result.size === 0 && attempts >= maxAttempts) {
-                    this.logger.error(`[ADB] File size is still 0 after ${maxAttempts} attempts.`);
-                    vscode.window.showErrorMessage(Constants.Messages.Error.RecordingEmpty);
-                    return;
-                }
-
-                previousSize = result.size;
-                await new Promise(resolve => setTimeout(resolve, 500));
-            }
-        };
-
-        await checkLoop();
-    }
-
-    private async pullRecording(deviceId: string, remotePath: string) {
-        const tmpDir = os.tmpdir();
-        const now = new Date();
-        const filename = `screenrecord_${now.getFullYear()}${(now.getMonth() + 1).toString().padStart(2, '0')}${now.getDate().toString().padStart(2, '0')}_${now.getHours().toString().padStart(2, '0')}${now.getMinutes().toString().padStart(2, '0')}${now.getSeconds().toString().padStart(2, '0')}.mp4`;
-        const localPath = path.join(tmpDir, filename);
-
-        const adbPath = this.getAdbPath();
-
-        vscode.window.withProgress({
-            location: vscode.ProgressLocation.Notification,
-            title: "Pulling screen recording...",
-            cancellable: false
-        }, async (_progress) => {
-            return new Promise<void>((resolve) => {
-                const pullCmd = `${adbPath} -s ${deviceId} pull ${remotePath} "${localPath}"`;
-                this.logger.info(`[ADB] Pulling video: ${pullCmd}`);
-
-                cp.execFile(adbPath, ['-s', deviceId, 'pull', remotePath, localPath], async (err) => {
-                    if (err) {
-                        this.logger.error(`[ADB] Failed to pull recording: ${err.message}`);
-                        vscode.window.showErrorMessage(Constants.Messages.Error.RetrieveRecordingFailed);
-                    } else {
-                        this.logger.info(`[ADB] Video pulled successfully to ${localPath}`);
-                        const uri = vscode.Uri.file(localPath);
-                        await vscode.commands.executeCommand('vscode.open', uri);
-                    }
-
-                    // Cleanup remote
-                    cp.execFile(adbPath, ['-s', deviceId, 'shell', 'rm', remotePath], (cleanupErr) => {
-                        if (cleanupErr) {
-                            this.logger.warn(`[ADB] Failed to cleanup remote file: ${cleanupErr.message}`);
-                        } else {
-                            this.logger.info(`[ADB] Remote file cleaned up`);
-                        }
-                        resolve();
-                    });
-                });
-            });
-        });
-    }
-
-    public async getShowTouchesState(deviceId: string): Promise<boolean> {
-        return new Promise((resolve) => {
-            const adbPath = this.getAdbPath();
-            const cmd = `${adbPath} -s ${deviceId} shell settings get system show_touches`;
-            this.logger.info(`[ADB] Getting show_touches: ${cmd}`);
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'settings', 'get', 'system', 'show_touches'], (err, stdout) => {
-                if (err) {
-                    this.logger.error(`[ADB] Failed to get show_touches: ${err.message}`);
-                    resolve(false);
-                    return;
-                }
-                const result = stdout.trim();
-                resolve(result === '1');
-            });
-        });
-    }
-
-    public async setShowTouchesState(deviceId: string, enable: boolean): Promise<void> {
-        return new Promise((resolve) => {
-            const adbPath = this.getAdbPath();
-            const value = enable ? '1' : '0';
-            const cmd = `${adbPath} -s ${deviceId} shell settings put system show_touches ${value}`;
-            this.logger.info(`[ADB] Setting show_touches: ${cmd}`);
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'settings', 'put', 'system', 'show_touches', value], (err) => {
-                if (err) {
-                    this.logger.error(`[ADB] Failed to set show_touches: ${err.message}`);
-                }
-                this._onDidChangeSessions.fire(); // Trigger refresh
-                resolve();
-            });
-        });
-    }
-
-    public async toggleShowTouches(deviceId: string): Promise<void> {
-        const current = await this.getShowTouchesState(deviceId);
-        await this.setShowTouchesState(deviceId, !current);
-    }
-
-    public async getSystemInfo(deviceId: string): Promise<string> {
-        return new Promise((resolve, reject) => {
-            const adbPath = this.getAdbPath();
-            // multiple commands: getprop ro.product.model, ro.build.version.release, ro.build.display.id
-            // and cat /proc/meminfo
-            const cmd = `${adbPath} -s ${deviceId} shell "getprop ro.product.model && echo '---' && getprop ro.build.version.release && echo '---' && getprop ro.build.display.id && echo '---' && cat /proc/meminfo"`;
-            this.logger.info(`[ADB] Getting system info: ${cmd}`);
-
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'echo "Model:" && getprop ro.product.model && echo "Android Version:" && getprop ro.build.version.release && echo "Build ID:" && getprop ro.build.display.id && echo "\n--- MEMINFO ---" && cat /proc/meminfo'], (err, stdout) => {
-                if (err) {
-                    this.logger.error(`[ADB] Failed to get system info: ${err.message}`);
-                    reject(err);
-                    return;
-                }
-                resolve(stdout);
-            });
-        });
-    }
-
-    public async getSystemProperties(deviceId: string): Promise<string> {
-        return new Promise((resolve, reject) => {
-            const adbPath = this.getAdbPath();
-            this.logger.info(`[ADB] Getting system properties on ${deviceId}`);
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'getprop'], (err, stdout) => {
-                if (err) {
-                    this.logger.error(`[ADB] Failed to get system properties: ${err.message}`);
-                    reject(err);
-                    return;
-                }
-                resolve(stdout);
-            });
-        });
-    }
-
-    public async runDumpsysAudioPolicy(deviceId: string): Promise<string> {
-        return new Promise((resolve, reject) => {
-            const adbPath = this.getAdbPath();
-            // Try media.audio_policy first, if empty, try audio
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'dumpsys', 'media.audio_policy'], (err, stdout) => {
-                if (!err && stdout && stdout.trim().length > 0 && !stdout.includes('Can\'t find service')) {
-                    resolve(stdout);
-                } else {
-                    // Fallback to 'audio'
-                    this.logger.info(`[ADB] media.audio_policy failed or empty, trying 'audio'`);
-                    cp.execFile(adbPath, ['-s', deviceId, 'shell', 'dumpsys', 'audio'], (err2, stdout2) => {
-                        if (err2) {
-                            reject(err2);
-                        } else {
-                            resolve(stdout2);
-                        }
-                    });
-                }
-            });
-        });
-    }
-
-    public async runDumpsysMediaSession(deviceId: string): Promise<string> {
-        return new Promise((resolve, reject) => {
-            const adbPath = this.getAdbPath();
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'dumpsys', 'media_session'], (err, stdout) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(stdout);
-                }
-            });
-        });
-    }
-
-    public async runDumpsysAudioFlinger(deviceId: string): Promise<string> {
-        return new Promise((resolve, reject) => {
-            const adbPath = this.getAdbPath();
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'dumpsys', 'media.audio_flinger'], (err, stdout) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(stdout);
-                }
-            });
-        });
+        return this.targetAppService.runDumpsysActivity(deviceId, packageName);
     }
 
     public async launchApp(deviceId: string, packageName: string): Promise<boolean> {
-        return new Promise((resolve) => {
-            const adbPath = this.getAdbPath();
-            this.logger.info(`[ADB] Launching ${packageName} on ${deviceId}`);
-            // monkey -p <package> -c android.intent.category.LAUNCHER 1
-            cp.execFile(adbPath, ['-s', deviceId, 'shell', 'monkey', '-p', packageName, '-c', 'android.intent.category.LAUNCHER', '1'], (err, stdout) => {
-                if (err) {
-                    this.logger.error(`[ADB] Launch app failed: ${err.message}`);
-                    resolve(false);
-                    return;
-                }
-                this.logger.info(`[ADB] Launch app output: ${stdout.trim()}`);
-                // Monkey output usually contains "Events injected: 1" on success
-                resolve(stdout.includes('Events injected'));
-            });
-        });
+        return this.targetAppService.launchApp(deviceId, packageName);
+    }
+
+    // Logcat
+    public createSession(name: string, device: AdbDevice): LogcatSession {
+        return this.logcatService.createSession(name, device);
+    }
+
+    public getSessions(): LogcatSession[] {
+        return this.logcatService.getSessions();
+    }
+
+    public getSession(id: string): LogcatSession | undefined {
+        return this.logcatService.getSession(id);
+    }
+
+    public removeSession(id: string) {
+        this.logcatService.removeSession(id);
+    }
+
+    public async startSession(sessionId: string) {
+        return this.logcatService.startSession(sessionId);
+    }
+
+    public stopSession(sessionId: string) {
+        this.logcatService.stopSession(sessionId);
+    }
+
+    public addTag(sessionId: string, tag: LogcatTag) {
+        this.logcatService.addTag(sessionId, tag);
+    }
+
+    public removeTag(sessionId: string, tagId: string) {
+        this.logcatService.removeTag(sessionId, tagId);
+    }
+
+    public updateTag(sessionId: string, tag: LogcatTag) {
+        this.logcatService.updateTag(sessionId, tag);
+    }
+
+    public toggleSessionTimeFilter(sessionId: string) {
+        this.logcatService.toggleSessionTimeFilter(sessionId);
+    }
+
+    // Device Controls
+    public async captureScreenshot(deviceId: string, localOutputPath: string): Promise<boolean> {
+        return this.deviceService.captureScreenshot(deviceId, localOutputPath);
+    }
+
+    public isDeviceRecording(deviceId: string): boolean {
+        return this.deviceService.isDeviceRecording(deviceId);
+    }
+
+    public isDeviceStopping(deviceId: string): boolean {
+        return this.deviceService.isDeviceStopping(deviceId);
+    }
+
+    public async startRecording(deviceId: string): Promise<boolean> {
+        return this.deviceService.startRecording(deviceId);
+    }
+
+    public async stopRecording(deviceId: string): Promise<void> {
+        return this.deviceService.stopRecording(deviceId);
+    }
+
+    public async getShowTouchesState(deviceId: string): Promise<boolean> {
+        return this.deviceService.getShowTouchesState(deviceId);
+    }
+
+    public async setShowTouchesState(deviceId: string, enable: boolean): Promise<void> {
+        return this.deviceService.setShowTouchesState(deviceId, enable);
+    }
+
+    public async toggleShowTouches(deviceId: string): Promise<void> {
+        return this.deviceService.toggleShowTouches(deviceId);
+    }
+
+    public async getSystemInfo(deviceId: string): Promise<string> {
+        return this.deviceService.getSystemInfo(deviceId);
+    }
+
+    public async getSystemProperties(deviceId: string): Promise<string> {
+        return this.deviceService.getSystemProperties(deviceId);
     }
 
     public async installApk(deviceId: string, filePath: string): Promise<boolean> {
-        return new Promise((resolve) => {
-            const adbPath = this.getAdbPath();
-            this.logger.info(`[ADB] Installing ${filePath} to ${deviceId}`);
-            cp.execFile(adbPath, ['-s', deviceId, 'install', '-r', filePath], (err, stdout) => {
-                if (err) {
-                    this.logger.error(`[ADB] Install failed: ${err.message}`);
-                    resolve(false);
-                    return;
-                }
-                this.logger.info(`[ADB] Install output: ${stdout.trim()}`);
-                resolve(stdout.includes('Success'));
-            });
-        });
+        return this.deviceService.installApk(deviceId, filePath);
+    }
+
+    public async runDumpsysAudioPolicy(deviceId: string): Promise<string> {
+        return this.deviceService.runDumpsysAudioPolicy(deviceId);
+    }
+
+    public async runDumpsysMediaSession(deviceId: string): Promise<string> {
+        return this.deviceService.runDumpsysMediaSession(deviceId);
+    }
+
+    public async runDumpsysAudioFlinger(deviceId: string): Promise<string> {
+        return this.deviceService.runDumpsysAudioFlinger(deviceId);
     }
 
     public dispose() {
-        this.flushTimers.forEach(timer => clearInterval(timer));
-        this.flushTimers.clear();
-
-        this.processes.forEach(proc => proc.kill());
-        this.processes.clear();
-
-        this.recordingProcesses.forEach(info => {
-            if (info.process) {
-                info.process.kill();
-            }
-        });
-        this.recordingProcesses.clear();
-
+        this.logcatService.dispose();
+        // deviceService doesn't have disposable resources (process cleanup handles itself or on demand)
+        // targetAppService doesn't have disposable resources
         this._onDidChangeSessions.dispose();
     }
 }

--- a/src/services/adb/AdbClient.ts
+++ b/src/services/adb/AdbClient.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import { Constants } from '../../Constants';
+import { Logger } from '../Logger';
+
+export class AdbClient {
+    constructor(private logger: Logger) { }
+
+    public getAdbPath(): string {
+        return vscode.workspace.getConfiguration(Constants.Configuration.Section).get<string>(Constants.Configuration.Adb.Path) || Constants.Defaults.AdbPath;
+    }
+
+    public async execAdb(args: string[], options?: cp.ExecFileOptions): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const adbPath = this.getAdbPath();
+            cp.execFile(adbPath, args, options, (err, stdout, stderr) => {
+                if (err) {
+                    reject(new Error(`${err.message} (stderr: ${stderr})`));
+                    return;
+                }
+                resolve(stdout.toString());
+            });
+        });
+    }
+
+    public spawnAdb(args: string[], options?: cp.SpawnOptions): cp.ChildProcess {
+        const adbPath = this.getAdbPath();
+        return cp.spawn(adbPath, args, options || {});
+    }
+}

--- a/src/services/adb/AdbDeviceService.ts
+++ b/src/services/adb/AdbDeviceService.ts
@@ -1,0 +1,345 @@
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
+import { AdbDevice } from '../../models/AdbModels';
+import { Logger } from '../Logger';
+import { Constants } from '../../Constants';
+import { AdbClient } from './AdbClient';
+
+export class AdbDeviceService {
+    private recordingProcesses: Map<string, { process: cp.ChildProcess, remotePath: string, pid?: string }> = new Map();
+    private stoppingDevices: Set<string> = new Set();
+    private _onDidChangeRecordingStatus = new vscode.EventEmitter<void>();
+    public readonly onDidChangeRecordingStatus = this._onDidChangeRecordingStatus.event;
+
+    constructor(private logger: Logger, private client: AdbClient) { }
+
+    public async getDevices(): Promise<AdbDevice[]> {
+        const adbPath = this.client.getAdbPath(); // Still need path for logging consistency? Or use client wrapper fully?
+        // Using client wrapper for execution
+        this.logger.info(`[ADB] Executing: ${adbPath} devices -l`);
+
+        try {
+            const stdout = await this.client.execAdb(['devices', '-l']);
+            this.logger.info(`[ADB] Raw output:\n${stdout.trim()}`);
+
+            const devices: AdbDevice[] = [];
+            const lines = stdout.split('\n');
+            for (const line of lines) {
+                if (!line.trim() || line.startsWith('List of devices attached')) {
+                    continue;
+                }
+                const parts = line.split(/\s+/);
+                if (parts.length >= 2) {
+                    const id = parts[0];
+                    const type = parts[1];
+                    const device: AdbDevice = { id, type };
+
+                    for (let i = 2; i < parts.length; i++) {
+                        const [key, value] = parts[i].split(':');
+                        if (key && value) {
+                            if (key === 'transport_id') {
+                                device.transportId = value;
+                            } else if (key === 'product') {
+                                device.product = value;
+                            } else if (key === 'model') {
+                                device.model = value;
+                            } else if (key === 'device') {
+                                device.device = value;
+                            }
+                        }
+                    }
+                    this.logger.info(`[ADB] Parsed device: ${JSON.stringify(device)}`);
+                    devices.push(device);
+                }
+            }
+            return devices;
+        } catch (err: unknown) {
+            const errorMessage = err instanceof Error ? err.message : String(err);
+            this.logger.error(`[ADB] Error running adb devices: ${errorMessage}`);
+            return [];
+        }
+    }
+
+    public async captureScreenshot(deviceId: string, localOutputPath: string): Promise<boolean> {
+        const remotePath = `/data/local/tmp/vscode_screenshot_${Date.now()}.png`;
+        this.logger.info(`[ADB] Capturing screenshot on ${deviceId} to ${remotePath}`);
+
+        try {
+            await this.client.execAdb(['-s', deviceId, 'shell', 'screencap', '-p', remotePath]);
+
+            this.logger.info(`[ADB] Pulling screenshot to ${localOutputPath}`);
+            await this.client.execAdb(['-s', deviceId, 'pull', remotePath, localOutputPath]);
+
+            // Cleanup
+            this.client.execAdb(['-s', deviceId, 'shell', 'rm', remotePath]).catch(() => {
+                // Ignore cleanup error
+            });
+            return true;
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            this.logger.error(`[ADB] Screenshot failed: ${msg}`);
+            if (!deviceId) { return false; }
+            if (!this.client) { return false; }
+            this.client.execAdb(['-s', deviceId, 'shell', 'rm', remotePath]).catch(() => {
+                // Ignore cleanup error
+            });
+            return false;
+        }
+    }
+
+    // Recording Logic
+    public isDeviceRecording(deviceId: string): boolean {
+        return this.recordingProcesses.has(deviceId);
+    }
+
+    public isDeviceStopping(deviceId: string): boolean {
+        return this.stoppingDevices.has(deviceId);
+    }
+
+    public async startRecording(deviceId: string): Promise<boolean> {
+        if (this.isDeviceRecording(deviceId) || this.isDeviceStopping(deviceId)) {
+            return false;
+        }
+
+        const timestamp = new Date().getTime();
+        const remotePath = `/data/local/tmp/screenrecord_${timestamp}.mp4`;
+        this.logger.info(`[ADB] Starting recording on ${deviceId} to ${remotePath}`);
+
+        // Spawn manually to handle pipes similar to original implementation
+        const adbPath = this.client.getAdbPath();
+        const args = ['-s', deviceId, 'shell', 'screenrecord', remotePath];
+        const child = cp.spawn(adbPath, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+
+        if (child.stdout) { child.stdout.on('data', d => this.logger.info(`[ADB][screenrecord] stdout: ${d}`)); }
+        if (child.stderr) { child.stderr.on('data', d => this.logger.error(`[ADB][screenrecord] stderr: ${d}`)); }
+
+        child.on('error', (err) => {
+            this.logger.error(`[ADB] Failed to start screenrecord: ${err.message}`);
+            this.recordingProcesses.delete(deviceId);
+            this._onDidChangeRecordingStatus.fire();
+            vscode.window.showErrorMessage(Constants.Messages.Error.RecordingFailed.replace('{0}', err.message));
+        });
+
+        child.on('close', async (code) => {
+            this.logger.info(`[ADB] Local adb process closed on ${deviceId} (code ${code})`);
+            this.recordingProcesses.delete(deviceId);
+            this._onDidChangeRecordingStatus.fire();
+
+            await this.checkAndPullRecording(deviceId, remotePath);
+
+            if (this.stoppingDevices.has(deviceId)) {
+                this.stoppingDevices.delete(deviceId);
+                this._onDidChangeRecordingStatus.fire();
+            }
+        });
+
+        this.recordingProcesses.set(deviceId, { process: child, remotePath });
+        this._onDidChangeRecordingStatus.fire();
+
+        // Find PID async
+        this.findPid(deviceId, 'screenrecord').then(pid => {
+            const info = this.recordingProcesses.get(deviceId);
+            if (info && pid) {
+                info.pid = pid;
+            }
+        });
+
+        return true;
+    }
+
+    public async stopRecording(deviceId: string): Promise<void> {
+        const info = this.recordingProcesses.get(deviceId);
+        if (!info) {
+            return;
+        }
+
+        this.stoppingDevices.add(deviceId);
+        this._onDidChangeRecordingStatus.fire();
+
+        // 1. Send SIGINT to remote
+        const pid = info.pid || await this.findPid(deviceId, 'screenrecord');
+        if (pid) {
+            this.client.execAdb(['-s', deviceId, 'shell', 'kill', '-2', pid]).catch(e => this.logger.warn(`Failed to kill -2: ${e}`));
+        } else {
+            this.logger.warn(`[ADB] Could not determine remote PID. Stopping local process only.`);
+        }
+
+        // 2. Wait
+        const maxWait = 5000;
+        const start = Date.now();
+        while (Date.now() - start < maxWait) {
+            const currentPid = await this.findPid(deviceId, 'screenrecord');
+            if (!currentPid) {
+                break;
+            }
+            await new Promise(r => setTimeout(r, 500));
+        }
+
+        // 3. Kill local
+        if (info.process) {
+            info.process.kill();
+        }
+    }
+
+    private async checkAndPullRecording(deviceId: string, remotePath: string) {
+        let attempts = 0;
+        const maxAttempts = 10;
+        let previousSize = 0;
+
+        while (attempts < maxAttempts) {
+            attempts++;
+            let size = 0;
+            try {
+                const stdout = await this.client.execAdb(['-s', deviceId, 'shell', 'ls', '-l', remotePath]);
+                const parts = stdout.trim().split(/\s+/);
+                if (parts.length >= 5) { size = parseInt(parts[4], 10); }
+            } catch { /* ignore */ }
+
+            this.logger.info(`[ADB] File size check (${attempts}/${maxAttempts}): ${size} bytes`);
+
+            if (size > 0 && size === previousSize) {
+                await this.pullRecording(deviceId, remotePath);
+                return;
+            } else if (size > 0 && attempts >= maxAttempts) {
+                await this.pullRecording(deviceId, remotePath);
+                return;
+            } else if (size === 0 && attempts >= maxAttempts) {
+                vscode.window.showErrorMessage(Constants.Messages.Error.RecordingEmpty);
+                return;
+            }
+            previousSize = size;
+            await new Promise(r => setTimeout(r, 500));
+        }
+    }
+
+    private async pullRecording(deviceId: string, remotePath: string) {
+        const tmpDir = os.tmpdir();
+        const now = new Date();
+        const filename = `screenrecord_${now.getFullYear()}${(now.getMonth() + 1).toString().padStart(2, '0')}${now.getDate().toString().padStart(2, '0')}_${now.getHours().toString().padStart(2, '0')}${now.getMinutes().toString().padStart(2, '0')}${now.getSeconds().toString().padStart(2, '0')}.mp4`;
+        const localPath = path.join(tmpDir, filename);
+
+        vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: "Pulling screen recording...",
+            cancellable: false
+        }, async () => {
+            try {
+                await this.client.execAdb(['-s', deviceId, 'pull', remotePath, localPath]);
+                const uri = vscode.Uri.file(localPath);
+                await vscode.commands.executeCommand('vscode.open', uri);
+            } catch (_e: unknown) {
+                vscode.window.showErrorMessage(Constants.Messages.Error.RetrieveRecordingFailed);
+            }
+            // Cleanup
+            this.client.execAdb(['-s', deviceId, 'shell', 'rm', remotePath]).catch(() => { });
+        });
+    }
+
+    private async findPid(deviceId: string, search: string): Promise<string | undefined> {
+        // Helper local to this service for now, or could make public if needed
+        try {
+            const stdout = await this.client.execAdb(['-s', deviceId, 'shell', 'pidof', '-s', search]);
+            if (stdout.trim()) {
+                return stdout.trim();
+            }
+        } catch (_e: unknown) {
+            // Ignore error
+        }
+
+        // Fallback ps -A
+        try {
+            const stdout = await this.client.execAdb(['-s', deviceId, 'shell', 'ps', '-A']);
+            const pid = this.parsePsForPid(stdout, search);
+            if (pid) {
+                return pid;
+            }
+        } catch (_e: unknown) {
+            // Ignore error
+        }
+
+        // Fallback ps
+        try {
+            const stdout = await this.client.execAdb(['-s', deviceId, 'shell', 'ps']);
+            return this.parsePsForPid(stdout, search);
+        } catch (_e: unknown) {
+            // Ignore error
+        }
+
+        return undefined;
+    }
+
+    private parsePsForPid(output: string, search: string): string | undefined {
+        const lines = output.split('\n');
+        for (const line of lines) {
+            const parts = line.trim().split(/\s+/);
+            if (parts.length < 9) {
+                continue;
+            }
+            const pid = parts[1];
+            const name = parts.slice(8).join(' ');
+            if (name === search || name.endsWith(`/${search}`)) {
+                return pid;
+            }
+        }
+        return undefined;
+    }
+
+    public async getShowTouchesState(deviceId: string): Promise<boolean> {
+        try {
+            const stdout = await this.client.execAdb(['-s', deviceId, 'shell', 'settings', 'get', 'system', 'show_touches']);
+            return stdout.trim() === '1';
+        } catch (_e: unknown) { return false; }
+    }
+
+    public async setShowTouchesState(deviceId: string, enable: boolean): Promise<void> {
+        const value = enable ? '1' : '0';
+        try {
+            await this.client.execAdb(['-s', deviceId, 'shell', 'settings', 'put', 'system', 'show_touches', value]);
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e);
+            this.logger.error(`Failed to set show touches: ${msg}`);
+        }
+    }
+
+    public async toggleShowTouches(deviceId: string): Promise<void> {
+        const current = await this.getShowTouchesState(deviceId);
+        await this.setShowTouchesState(deviceId, !current);
+    }
+
+    public async getSystemInfo(deviceId: string): Promise<string> {
+        return this.client.execAdb(['-s', deviceId, 'shell', 'echo "Model:" && getprop ro.product.model && echo "Android Version:" && getprop ro.build.version.release && echo "Build ID:" && getprop ro.build.display.id && echo "\n--- MEMINFO ---" && cat /proc/meminfo']);
+    }
+
+    public async getSystemProperties(deviceId: string): Promise<string> {
+        return this.client.execAdb(['-s', deviceId, 'shell', 'getprop']);
+    }
+
+    public async installApk(deviceId: string, filePath: string): Promise<boolean> {
+        try {
+            const stdout = await this.client.execAdb(['-s', deviceId, 'install', '-r', filePath]);
+            return stdout.includes('Success');
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e);
+            this.logger.error(`Install failed: ${msg}`);
+            return false;
+        }
+    }
+
+    public async runDumpsysAudioPolicy(deviceId: string): Promise<string> {
+        try {
+            return await this.client.execAdb(['-s', deviceId, 'shell', 'dumpsys', 'media.audio_policy']);
+        } catch {
+            return this.client.execAdb(['-s', deviceId, 'shell', 'dumpsys', 'audio']);
+        }
+    }
+
+    public async runDumpsysMediaSession(deviceId: string): Promise<string> {
+        return this.client.execAdb(['-s', deviceId, 'shell', 'dumpsys', 'media_session']);
+    }
+
+    public async runDumpsysAudioFlinger(deviceId: string): Promise<string> {
+        return this.client.execAdb(['-s', deviceId, 'shell', 'dumpsys', 'media.audio_flinger']);
+    }
+}

--- a/src/services/adb/AdbLogcatService.ts
+++ b/src/services/adb/AdbLogcatService.ts
@@ -1,0 +1,271 @@
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import * as crypto from 'crypto';
+import { Logger } from '../Logger';
+import { Constants } from '../../Constants';
+import { AdbClient } from './AdbClient';
+import { LogcatSession, LogcatTag, AdbDevice } from '../../models/AdbModels';
+import { AdbTargetAppService } from './AdbTargetAppService';
+
+export class AdbLogcatService {
+    private sessions: Map<string, LogcatSession> = new Map();
+    private processes: Map<string, cp.ChildProcess> = new Map();
+    private buffers: Map<string, string[]> = new Map();
+    private flushTimers: Map<string, NodeJS.Timeout> = new Map();
+
+    private _onDidChangeSessions = new vscode.EventEmitter<void>();
+    public readonly onDidChangeSessions = this._onDidChangeSessions.event;
+
+    constructor(
+        private logger: Logger,
+        private client: AdbClient,
+        private targetAppService: AdbTargetAppService
+    ) { }
+
+    public getSessions(): LogcatSession[] {
+        return Array.from(this.sessions.values());
+    }
+
+    public getSession(id: string): LogcatSession | undefined {
+        return this.sessions.get(id);
+    }
+
+    public createSession(name: string, device: AdbDevice): LogcatSession {
+        const session: LogcatSession = {
+            id: crypto.randomUUID(),
+            name,
+            device,
+            tags: [],
+            isRunning: false,
+            useStartFromCurrentTime: true
+        };
+        this.sessions.set(session.id, session);
+        this._onDidChangeSessions.fire();
+        this.logger.info(`[Session] Created session '${name}' for device ${device.id}`);
+        return session;
+    }
+
+    public removeSession(id: string) {
+        this.stopSession(id);
+        this.sessions.delete(id);
+        this._onDidChangeSessions.fire();
+        this.logger.info(`[Session] Removed session ${id}`);
+    }
+
+    public async startSession(sessionId: string) {
+        const session = this.sessions.get(sessionId);
+        if (!session || session.isRunning) {
+            return;
+        }
+
+        // Verify document
+        if (session.outputDocumentUri) {
+            const uri = vscode.Uri.parse(session.outputDocumentUri);
+            const doc = vscode.workspace.textDocuments.find(d => d.uri.toString() === uri.toString());
+            if (!doc || doc.isClosed) {
+                session.outputDocumentUri = undefined;
+            }
+        }
+
+        try {
+            const adbPath = this.client.getAdbPath();
+            const defaultOptions = vscode.workspace.getConfiguration(Constants.Configuration.Section).get<string>(Constants.Configuration.Adb.DefaultOptions) || Constants.Defaults.AdbDefaultOptions;
+
+            const args = ['-s', session.device.id, 'logcat'];
+            const startFromNow = session.useStartFromCurrentTime !== false;
+
+            // Parse default options
+            if (defaultOptions.trim().length > 0) {
+                const parts = defaultOptions.split(/\s+/);
+                for (let i = 0; i < parts.length; i++) {
+                    const part = parts[i];
+                    if (part === '-T' || part === '-t') {
+                        if (!startFromNow) {
+                            i++;
+                            continue;
+                        }
+                    }
+                    args.push(part);
+                }
+            }
+
+            const hasTimeArg = args.includes('-T') || args.includes('-t');
+            if (startFromNow && !hasTimeArg) {
+                args.push('-T', '1');
+            }
+
+            // PID Filter
+            if (session.device.targetApp && session.device.targetApp !== 'all') {
+                const pid = await this.targetAppService.getAppPid(session.device.id, session.device.targetApp);
+                if (pid) {
+                    this.logger.info(`[ADB] Resolved PID for ${session.device.targetApp}: ${pid}`);
+                    args.push(`--pid=${pid}`);
+                } else {
+                    vscode.window.showWarningMessage(Constants.Messages.Warn.AppNotRunning.replace('{0}', session.device.targetApp));
+                }
+            }
+
+            // Tag filters
+            if (session.tags.length > 0) {
+                session.tags.forEach(tag => {
+                    if (tag.isEnabled) {
+                        args.push(`${tag.name}:${tag.priority}`);
+                    }
+                });
+                args.push('*:S');
+            } else {
+                args.push('*:V');
+            }
+
+            this.logger.info(`[ADB] Starting logcat: ${adbPath} ${args.join(' ')}`);
+            const child = this.client.spawnAdb(args);
+            this.processes.set(sessionId, child);
+            session.isRunning = true;
+            this._onDidChangeSessions.fire();
+
+            if (!session.outputDocumentUri) {
+                await this.createLogDocument(session, args.join(' '));
+            }
+
+            child.stdout?.on('data', data => this.bufferLogs(sessionId, data.toString().split('\n')));
+            child.stderr?.on('data', data => this.bufferLogs(sessionId, data.toString().split('\n').map((l: string) => `[STDERR] ${l}`)));
+
+            child.on('close', (code) => {
+                this.logger.info(`[ADB] Logcat process exited: ${code}`);
+                session.isRunning = false;
+                this.processes.delete(sessionId);
+                this._onDidChangeSessions.fire();
+                this.flushLogs(sessionId);
+            });
+
+            child.on('error', (err) => {
+                this.logger.error(`[ADB] Logcat error: ${err.message}`);
+                vscode.window.showErrorMessage(Constants.Messages.Error.LogcatStartFailed.replace('{0}', err.message));
+                session.isRunning = false;
+                this._onDidChangeSessions.fire();
+            });
+
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e);
+            this.logger.error(`[ADB] Exception starting logcat: ${msg}`);
+            vscode.window.showErrorMessage(Constants.Messages.Error.LogcatStartFailed.replace('{0}', msg));
+        }
+    }
+
+    private async createLogDocument(session: LogcatSession, command: string) {
+        const now = new Date();
+        const header = `Logcat session: ${session.name}\nCommand: adb ${command}\nDate: ${now.toISOString()}\n${'='.repeat(80)}\n`;
+        const doc = await vscode.workspace.openTextDocument({ language: 'log', content: header });
+        await vscode.window.showTextDocument(doc, { preview: false, preserveFocus: true });
+        session.outputDocumentUri = doc.uri.toString();
+    }
+
+    public stopSession(sessionId: string) {
+        const child = this.processes.get(sessionId);
+        if (child) {
+            child.kill();
+            this.processes.delete(sessionId);
+        }
+        const session = this.sessions.get(sessionId);
+        if (session) {
+            session.isRunning = false;
+            this._onDidChangeSessions.fire();
+        }
+        const timer = this.flushTimers.get(sessionId);
+        if (timer) {
+            clearInterval(timer);
+            this.flushTimers.delete(sessionId);
+        }
+    }
+
+    public addTag(sessionId: string, tag: LogcatTag) {
+        const session = this.sessions.get(sessionId);
+        if (session && !session.isRunning) {
+            session.tags.push(tag);
+            this._onDidChangeSessions.fire();
+        }
+    }
+
+    public removeTag(sessionId: string, tagId: string) {
+        const session = this.sessions.get(sessionId);
+        if (session && !session.isRunning) {
+            session.tags = session.tags.filter(t => t.id !== tagId);
+            this._onDidChangeSessions.fire();
+        }
+    }
+
+    public updateTag(sessionId: string, tag: LogcatTag) {
+        const session = this.sessions.get(sessionId);
+        if (session && !session.isRunning) {
+            const index = session.tags.findIndex(t => t.id === tag.id);
+            if (index !== -1) {
+                session.tags[index] = tag;
+                this._onDidChangeSessions.fire();
+            }
+        }
+    }
+
+    public toggleSessionTimeFilter(sessionId: string) {
+        const session = this.sessions.get(sessionId);
+        if (session && !session.isRunning) {
+            session.useStartFromCurrentTime = !session.useStartFromCurrentTime;
+            this._onDidChangeSessions.fire();
+        }
+    }
+
+    private bufferLogs(sessionId: string, lines: string[]) {
+        const buffer = this.buffers.get(sessionId) || [];
+        buffer.push(...lines.filter(l => l.length > 0));
+        this.buffers.set(sessionId, buffer);
+
+        if (!this.flushTimers.has(sessionId)) {
+            const timer = setInterval(() => this.flushLogs(sessionId), 500);
+            this.flushTimers.set(sessionId, timer);
+        }
+    }
+
+    private async flushLogs(sessionId: string) {
+        const buffer = this.buffers.get(sessionId);
+        if (!buffer || buffer.length === 0) {
+            return;
+        }
+
+        const session = this.sessions.get(sessionId);
+        if (!session || !session.outputDocumentUri) {
+            this.buffers.set(sessionId, []);
+            return;
+        }
+
+        const content = buffer.join('\n') + '\n';
+        this.buffers.set(sessionId, []);
+
+        try {
+            const uri = vscode.Uri.parse(session.outputDocumentUri);
+            const doc = vscode.workspace.textDocuments.find(d => d.uri.toString() === uri.toString());
+
+            if (doc) {
+                const edit = new vscode.WorkspaceEdit();
+                const pos = new vscode.Position(doc.lineCount, 0);
+                edit.insert(uri, pos, content);
+                if (await vscode.workspace.applyEdit(edit)) {
+                    // Auto-scroll
+                    const editor = vscode.window.visibleTextEditors.find(e => e.document.uri.toString() === uri.toString());
+                    if (editor) {
+                        const newPos = new vscode.Position(doc.lineCount - 1, 0);
+                        editor.revealRange(new vscode.Range(newPos, newPos));
+                    }
+                }
+            } else {
+                this.stopSession(sessionId);
+            }
+        } catch (e) {
+            this.logger.error(`Flush logs failed: ${e}`);
+        }
+    }
+
+    public dispose() {
+        this.flushTimers.forEach(clearInterval);
+        this.processes.forEach(p => p.kill());
+        this._onDidChangeSessions.dispose();
+    }
+}

--- a/src/services/adb/AdbTargetAppService.ts
+++ b/src/services/adb/AdbTargetAppService.ts
@@ -1,0 +1,193 @@
+import * as vscode from 'vscode';
+import { Logger } from '../Logger';
+import { AdbClient } from './AdbClient';
+import { AdbDevice } from '../../models/AdbModels';
+
+export class AdbTargetAppService {
+    private deviceTargetApps: Map<string, string> = new Map(); // deviceId -> packageName
+    private _onDidChangeTargetApp = new vscode.EventEmitter<void>();
+    public readonly onDidChangeTargetApp = this._onDidChangeTargetApp.event;
+
+    constructor(private logger: Logger, private client: AdbClient) { }
+
+    public setTargetApp(device: AdbDevice, packageName: string) {
+        this.deviceTargetApps.set(device.id, packageName);
+        device.targetApp = packageName;
+        this._onDidChangeTargetApp.fire();
+    }
+
+    public getTargetApp(deviceId: string): string | undefined {
+        return this.deviceTargetApps.get(deviceId);
+    }
+
+    public async getInstalledPackages(deviceId: string): Promise<string[]> {
+        const packages = await this.fetchPackages(deviceId);
+        return Array.from(packages).sort();
+    }
+
+    public async getThirdPartyPackages(deviceId: string): Promise<Set<string>> {
+        return this.fetchPackages(deviceId, '-3');
+    }
+
+    private async fetchPackages(deviceId: string, filter: string = ''): Promise<Set<string>> {
+        const args = ['-s', deviceId, 'shell', 'pm', 'list', 'packages'];
+        if (filter) { args.push(filter); }
+
+        try {
+            const stdout = await this.client.execAdb(args);
+            const packages = stdout.split('\n')
+                .filter(line => line.startsWith('package:'))
+                .map(line => line.replace('package:', '').trim());
+            return new Set(packages);
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            this.logger.error(`[ADB] Error getting packages: ${msg}`);
+            return new Set();
+        }
+    }
+
+    public async getRunningApps(deviceId: string): Promise<Set<string>> {
+        try {
+            const stdout = await this.client.execAdb(['-s', deviceId, 'shell', 'ps', '-A']);
+            return this.parsePsOutput(stdout);
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            this.logger.warn(`[ADB] ps -A failed, trying ps: ${msg}`);
+            try {
+                const stdout2 = await this.client.execAdb(['-s', deviceId, 'shell', 'ps']);
+                return this.parsePsOutput(stdout2);
+            } catch (err2: unknown) {
+                const msg2 = err2 instanceof Error ? err2.message : String(err2);
+                this.logger.error(`[ADB] Error getting running apps: ${msg2}`);
+                return new Set();
+            }
+        }
+    }
+
+    private parsePsOutput(output: string): Set<string> {
+        const running = new Set<string>();
+        const lines = output.split('\n');
+        for (const line of lines) {
+            const parts = line.trim().split(/\s+/);
+            if (parts.length >= 9) {
+                const name = parts.slice(8).join(' ');
+                if (name && name.includes('.') && !name.startsWith('[')) {
+                    running.add(name);
+                }
+            } else if (parts.length > 0) {
+                const name = parts[parts.length - 1];
+                if (name && name.includes('.') && !name.startsWith('[')) {
+                    running.add(name);
+                }
+            }
+        }
+        return running;
+    }
+
+    public async getAppPid(deviceId: string, packageName: string): Promise<string | undefined> {
+        return this.findPid(deviceId, packageName);
+    }
+
+    private async findPid(deviceId: string, search: string): Promise<string | undefined> {
+        try {
+            const stdout = await this.client.execAdb(['-s', deviceId, 'shell', 'pidof', '-s', search]);
+            if (stdout.trim()) {
+                return stdout.trim();
+            }
+        } catch {
+            // Ignore error
+        }
+
+        try {
+            const stdout = await this.client.execAdb(['-s', deviceId, 'shell', 'ps', '-A']);
+            if (stdout) {
+                return this.parsePsForPid(stdout, search);
+            }
+        } catch {
+            // Ignore error
+        }
+
+        try {
+            const stdout = await this.client.execAdb(['-s', deviceId, 'shell', 'ps']);
+            if (stdout) {
+                return this.parsePsForPid(stdout, search);
+            }
+        } catch {
+            // Ignore error
+        }
+
+        return undefined;
+    }
+
+    private parsePsForPid(output: string, search: string): string | undefined {
+        const lines = output.split('\n');
+        for (const line of lines) {
+            const parts = line.trim().split(/\s+/);
+            if (parts.length < 9) {
+                continue;
+            }
+            const pid = parts[1];
+            const name = parts.slice(8).join(' ');
+            if (name === search || name.endsWith(`/${search}`)) {
+                return pid;
+            }
+        }
+        return undefined;
+    }
+
+    public async uninstallApp(deviceId: string, packageName: string): Promise<boolean> {
+        try {
+            const stdout = await this.client.execAdb(['-s', deviceId, 'uninstall', packageName]);
+            return stdout.includes('Success');
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e);
+            this.logger.error(`Uninstall failed: ${msg}`);
+            return false;
+        }
+    }
+
+    public async clearAppStorage(deviceId: string, packageName: string): Promise<boolean> {
+        try {
+            const stdout = await this.client.execAdb(['-s', deviceId, 'shell', 'pm', 'clear', packageName]);
+            return stdout.includes('Success');
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e);
+            this.logger.error(`Clear storage failed: ${msg}`);
+            return false;
+        }
+    }
+
+    public async clearAppCache(deviceId: string, packageName: string): Promise<boolean> {
+        try {
+            await this.client.execAdb(['-s', deviceId, 'shell', 'run-as', packageName, 'rm', '-rf', 'cache', 'code_cache']);
+            return true;
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e);
+            this.logger.warn(`Clear cache failed: ${msg}`);
+            return false;
+        }
+    }
+
+    public async runDumpsysPackage(deviceId: string, packageName: string): Promise<string> {
+        return this.client.execAdb(['-s', deviceId, 'shell', 'dumpsys', 'package', packageName], { maxBuffer: 1024 * 1024 * 10 });
+    }
+
+    public async runDumpsysMeminfo(deviceId: string, packageName: string): Promise<string> {
+        return this.client.execAdb(['-s', deviceId, 'shell', 'dumpsys', 'meminfo', packageName], { maxBuffer: 1024 * 1024 * 10 });
+    }
+
+    public async runDumpsysActivity(deviceId: string, packageName: string): Promise<string> {
+        return this.client.execAdb(['-s', deviceId, 'shell', 'dumpsys', 'activity', packageName], { maxBuffer: 1024 * 1024 * 10 });
+    }
+
+    public async launchApp(deviceId: string, packageName: string): Promise<boolean> {
+        try {
+            const stdout = await this.client.execAdb(['-s', deviceId, 'shell', 'monkey', '-p', packageName, '-c', 'android.intent.category.LAUNCHER', '1']);
+            return stdout.includes('Events injected');
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e);
+            this.logger.error(`Launch failed: ${msg}`);
+            return false;
+        }
+    }
+}

--- a/src/views/AdbDeviceTreeProvider.ts
+++ b/src/views/AdbDeviceTreeProvider.ts
@@ -340,7 +340,6 @@ export class AdbDeviceTreeProvider implements vscode.TreeDataProvider<AdbTreeIte
         return 'priority' in element && 'isEnabled' in element && 'name' in element;
     }
 
-
     private isDumpsysGroup(element: AdbTreeItem): element is DumpsysGroupItem {
         return 'type' in element && element.type === 'dumpsysGroup';
     }


### PR DESCRIPTION
Split the monolithic AdbService into focused services: AdbDeviceService, AdbTargetAppService, and AdbLogcatService. AdbService now acts as a facade to maintain backward compatibility.

Key changes:
- Create AdbClient for shared ADB command execution.
- Move device management and recording to AdbDeviceService.
- Move target app and package management to AdbTargetAppService.
- Move logcat session management to AdbLogcatService.
- Move dumpsys audio/media commands to AdbDeviceService.
- Clean up lint errors and ensure test coverage.