### PR TITLE
test: add comprehensive test coverage for services and commands

### DIFF
--- a/src/test/commands/AdbCommandManager.test.ts
+++ b/src/test/commands/AdbCommandManager.test.ts
@@ -1,0 +1,106 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { AdbCommandManager } from '../../commands/AdbCommandManager';
+import { AdbService } from '../../services/AdbService';
+import { AdbDeviceTreeProvider } from '../../views/AdbDeviceTreeProvider';
+import { MockExtensionContext } from '../utils/Mocks';
+import { AdbDevice, LogcatSession } from '../../models/AdbModels';
+
+suite('AdbCommandManager Test Suite', () => {
+    let mockContext: MockExtensionContext;
+    let mockService: AdbService;
+    let mockTreeProvider: AdbDeviceTreeProvider;
+    let registeredCommands: Map<string, (...args: unknown[]) => unknown>;
+    let originalRegisterCommand: typeof vscode.commands.registerCommand;
+
+    setup(() => {
+        mockContext = new MockExtensionContext();
+        registeredCommands = new Map();
+
+        originalRegisterCommand = vscode.commands.registerCommand;
+        vscode.commands.registerCommand = (command: string, callback: (...args: unknown[]) => unknown) => {
+            registeredCommands.set(command, callback);
+            return { dispose: () => { } };
+        };
+
+        mockService = {
+            getSessions: () => [],
+            createSession: () => { },
+            startSession: async () => { },
+            stopSession: () => { },
+            removeSession: () => { }
+        } as unknown as AdbService;
+
+        mockTreeProvider = {
+            refreshDevices: async () => { }
+        } as unknown as AdbDeviceTreeProvider;
+
+        new AdbCommandManager(
+            mockContext as unknown as vscode.ExtensionContext,
+            mockService,
+            mockTreeProvider,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            { onDidChangeSelection: () => ({ dispose: () => { } }) } as unknown as vscode.TreeView<any>
+        );
+
+        vscode.commands.registerCommand = originalRegisterCommand;
+    });
+
+    teardown(() => {
+        vscode.commands.registerCommand = originalRegisterCommand;
+    });
+
+    test('AddLogcatSession creates new session via input box', async () => {
+        const device: AdbDevice = { id: 'dev1', type: 'device' };
+
+        let createdSessionName = '';
+        mockService.createSession = (name: string, _dev: AdbDevice) => {
+            createdSessionName = name;
+            return {} as LogcatSession;
+        };
+
+        const originalShowInputBox = vscode.window.showInputBox;
+        vscode.window.showInputBox = async () => 'My Custom Session';
+
+        const addCmd = registeredCommands.get('logmagnifier.addLogcatSession');
+        assert.ok(addCmd, 'Command should be registered');
+
+        await addCmd(device);
+
+        vscode.window.showInputBox = originalShowInputBox;
+
+        assert.strictEqual(createdSessionName, 'My Custom Session');
+    });
+
+    test('StartLogcatSession delegates to AdbService', async () => {
+        const session: LogcatSession = { id: 'ses-1', name: 'Ses1', device: { id: 'dev1', type: 'device' }, tags: [], isRunning: false, useStartFromCurrentTime: true };
+
+        let startedId = '';
+        mockService.startSession = async (id: string) => {
+            startedId = id;
+        };
+
+        const startCmd = registeredCommands.get('logmagnifier.startLogcatSession');
+        assert.ok(startCmd);
+
+        await startCmd(session);
+
+        assert.strictEqual(startedId, 'ses-1');
+    });
+
+    test('StopLogcatSession delegates to AdbService', async () => {
+        const session: LogcatSession = { id: 'ses-1', name: 'Ses1', device: { id: 'dev1', type: 'device' }, tags: [], isRunning: true, useStartFromCurrentTime: true };
+
+        let stoppedId = '';
+        mockService.stopSession = (id: string) => {
+            stoppedId = id;
+        };
+
+        const stopCmd = registeredCommands.get('logmagnifier.stopLogcatSession');
+        assert.ok(stopCmd);
+
+        await stopCmd(session);
+
+        assert.strictEqual(stoppedId, 'ses-1');
+    });
+});

--- a/src/test/commands/EditorToggleCommandManager.test.ts
+++ b/src/test/commands/EditorToggleCommandManager.test.ts
@@ -1,0 +1,69 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { EditorToggleCommandManager } from '../../commands/EditorToggleCommandManager';
+import { QuickAccessProvider } from '../../views/QuickAccessProvider';
+import { JsonPrettyService } from '../../services/JsonPrettyService';
+import { MockExtensionContext } from '../utils/Mocks';
+
+suite('EditorToggleCommandManager Test Suite', () => {
+    let mockContext: MockExtensionContext;
+    let mockQuickAccessProvider: QuickAccessProvider;
+    let mockJsonPrettyService: JsonPrettyService;
+    let registeredCommands: Map<string, (...args: unknown[]) => unknown>;
+    let originalRegisterCommand: typeof vscode.commands.registerCommand;
+
+    setup(() => {
+        mockContext = new MockExtensionContext();
+        registeredCommands = new Map();
+
+        originalRegisterCommand = vscode.commands.registerCommand;
+        vscode.commands.registerCommand = (command: string, callback: (...args: unknown[]) => unknown) => {
+            registeredCommands.set(command, callback);
+            return { dispose: () => { } };
+        };
+
+        mockQuickAccessProvider = {
+            refresh: () => { },
+            toggleFileSizeUnit: () => { }
+        } as unknown as QuickAccessProvider;
+
+        mockJsonPrettyService = {
+            execute: async () => { }
+        } as unknown as JsonPrettyService;
+
+        new EditorToggleCommandManager(mockContext as unknown as vscode.ExtensionContext, mockQuickAccessProvider, mockJsonPrettyService);
+        vscode.commands.registerCommand = originalRegisterCommand;
+    });
+
+    teardown(() => {
+        vscode.commands.registerCommand = originalRegisterCommand;
+    });
+
+    test('ToggleWordWrap executes editor command', async () => {
+        let executedCommand = '';
+        const originalExecuteCommand = vscode.commands.executeCommand;
+
+        vscode.commands.executeCommand = (async <T>(cmd: string) => {
+            executedCommand = cmd;
+            return undefined as T;
+        }) as unknown as typeof vscode.commands.executeCommand;
+
+        const toggleCmd = registeredCommands.get('logmagnifier.toggleWordWrap');
+        assert.ok(toggleCmd);
+        await toggleCmd();
+
+        vscode.commands.executeCommand = originalExecuteCommand;
+        assert.strictEqual(executedCommand, 'editor.action.toggleWordWrap');
+    });
+
+    test('ApplyJsonPretty calls JsonPrettyService', async () => {
+        let executed = false;
+        mockJsonPrettyService.execute = async () => { executed = true; };
+
+        const applyCmd = registeredCommands.get('logmagnifier.applyJsonPretty');
+        assert.ok(applyCmd);
+        await applyCmd();
+
+        assert.strictEqual(executed, true);
+    });
+});

--- a/src/test/commands/NavigationCommandManager.test.ts
+++ b/src/test/commands/NavigationCommandManager.test.ts
@@ -1,0 +1,99 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { NavigationCommandManager } from '../../commands/NavigationCommandManager';
+import { FileHierarchyService } from '../../services/FileHierarchyService';
+import { MockExtensionContext } from '../utils/Mocks';
+import { Constants } from '../../Constants';
+
+suite('NavigationCommandManager Test Suite', () => {
+    let mockContext: MockExtensionContext;
+    let mockHierarchyService: FileHierarchyService;
+    let registeredCommands: Map<string, (...args: unknown[]) => unknown>;
+    let originalRegisterCommand: typeof vscode.commands.registerCommand;
+
+    setup(() => {
+        mockContext = new MockExtensionContext();
+        registeredCommands = new Map();
+
+        originalRegisterCommand = vscode.commands.registerCommand;
+        vscode.commands.registerCommand = (command: string, callback: (...args: unknown[]) => unknown) => {
+            registeredCommands.set(command, callback);
+            return { dispose: () => { } };
+        };
+
+        mockHierarchyService = {
+            getRoot: () => undefined,
+            getNode: () => undefined,
+            getChildren: () => [],
+            unregister: () => { }
+        } as unknown as FileHierarchyService;
+
+        new NavigationCommandManager(mockContext as unknown as vscode.ExtensionContext, mockHierarchyService);
+        vscode.commands.registerCommand = originalRegisterCommand;
+    });
+
+    teardown(() => {
+        vscode.commands.registerCommand = originalRegisterCommand;
+    });
+
+    test('HierarchyOpenParent executes openFile', async () => {
+        let openedUri: vscode.Uri | undefined;
+
+        const originalOpenTextDocument = vscode.workspace.openTextDocument;
+        const originalShowTextDocument = vscode.window.showTextDocument;
+
+        vscode.workspace.openTextDocument = (async (uri: unknown) => {
+            openedUri = uri as vscode.Uri;
+            return {} as vscode.TextDocument;
+        }) as unknown as typeof vscode.workspace.openTextDocument;
+        vscode.window.showTextDocument = async () => ({} as vscode.TextEditor);
+
+        const openCmd = registeredCommands.get(Constants.Commands.HierarchyOpenParent);
+        assert.ok(openCmd);
+
+        const testUri = vscode.Uri.file('/test.txt');
+        await openCmd(testUri);
+
+        vscode.workspace.openTextDocument = originalOpenTextDocument;
+        vscode.window.showTextDocument = originalShowTextDocument;
+
+        assert.strictEqual(openedUri?.fsPath, testUri.fsPath);
+    });
+
+    test('HierarchyShowFullTree shows quick pick', async () => {
+        let quickPickShown = false;
+        const originalCreateQuickPick = vscode.window.createQuickPick;
+
+        vscode.window.createQuickPick = (<T extends vscode.QuickPickItem>() => {
+            quickPickShown = true;
+            return {
+                items: [] as T[],
+                show: () => { },
+                onDidTriggerItemButton: () => ({ dispose: () => { } }),
+                onDidAccept: () => ({ dispose: () => { } }),
+                onDidHide: () => ({ dispose: () => { } }),
+                dispose: () => { }
+            } as unknown as vscode.QuickPick<T>;
+        }) as unknown as typeof vscode.window.createQuickPick;
+
+        const originalActiveTextEditorDescriptor = Object.getOwnPropertyDescriptor(vscode.window, 'activeTextEditor');
+        Object.defineProperty(vscode.window, 'activeTextEditor', {
+            get: () => ({ document: { uri: vscode.Uri.file('/test.txt') } }),
+            configurable: true
+        });
+
+        const treeCmd = registeredCommands.get(Constants.Commands.HierarchyShowFullTree);
+        assert.ok(treeCmd);
+        await treeCmd();
+
+        vscode.window.createQuickPick = originalCreateQuickPick;
+        if (originalActiveTextEditorDescriptor) {
+            Object.defineProperty(vscode.window, 'activeTextEditor', originalActiveTextEditorDescriptor);
+        } else {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            delete (vscode.window as any).activeTextEditor;
+        }
+
+        assert.strictEqual(quickPickShown, true);
+    });
+});

--- a/src/test/services/AdbClient.test.ts
+++ b/src/test/services/AdbClient.test.ts
@@ -1,0 +1,122 @@
+import * as assert from 'assert';
+import * as cpTypes from 'child_process';
+import * as vscode from 'vscode';
+import { AdbClient } from '../../services/adb/AdbClient';
+import { Logger } from '../../services/Logger';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const cp = require('child_process') as typeof cpTypes;
+
+suite('AdbClient Test Suite', () => {
+    let adbClient: AdbClient;
+    let logger: Logger;
+    let originalExecFile: PropertyDescriptor | undefined;
+    let originalSpawn: PropertyDescriptor | undefined;
+    let originalGetConfiguration: typeof vscode.workspace.getConfiguration;
+
+    setup(() => {
+        logger = {
+            info: () => { },
+            warn: () => { },
+            error: () => { },
+            dispose: () => { }
+        } as unknown as Logger;
+        adbClient = new AdbClient(logger);
+        originalExecFile = Object.getOwnPropertyDescriptor(cp, 'execFile');
+        originalSpawn = Object.getOwnPropertyDescriptor(cp, 'spawn');
+        originalGetConfiguration = vscode.workspace.getConfiguration;
+    });
+
+    teardown(() => {
+        logger.dispose();
+        if (originalExecFile) {
+            Object.defineProperty(cp, 'execFile', originalExecFile);
+        }
+        if (originalSpawn) {
+            Object.defineProperty(cp, 'spawn', originalSpawn);
+        }
+        vscode.workspace.getConfiguration = originalGetConfiguration;
+    });
+
+    test('getAdbPath returns configured path', () => {
+        // @ts-expect-error Mocking for test
+        vscode.workspace.getConfiguration = () => {
+            return {
+                get: (key: string) => {
+                    if (key === 'adbPath') { return '/custom/adb/path'; }
+                    return undefined;
+                }
+            };
+        };
+        assert.strictEqual(adbClient.getAdbPath(), '/custom/adb/path');
+    });
+
+    test('getAdbPath returns default path if not configured', () => {
+        // @ts-expect-error Mocking for test
+        vscode.workspace.getConfiguration = () => {
+            return {
+                get: (_key: string) => undefined
+            };
+        };
+        assert.strictEqual(adbClient.getAdbPath(), 'adb');
+    });
+
+    test('execAdb resolves with stdout on success', async () => {
+        // @ts-expect-error Mocking for test
+        vscode.workspace.getConfiguration = () => ({ get: () => 'adb' });
+
+        Object.defineProperty(cp, 'execFile', {
+            value: (_file: string, args: readonly string[], _options: cpTypes.ExecFileOptions, callback: (error: cpTypes.ExecException | null, stdout: string, stderr: string) => void) => {
+                assert.deepStrictEqual(args, ['devices']);
+                callback(null, 'device1\tdevice\n', '');
+                return {} as cpTypes.ChildProcess;
+            },
+            configurable: true
+        });
+
+        const result = await adbClient.execAdb(['devices'], {});
+        assert.strictEqual(result, 'device1\tdevice\n');
+    });
+
+    test('execAdb rejects with error on failure', async () => {
+        // @ts-expect-error Mocking for test
+        vscode.workspace.getConfiguration = () => ({ get: () => 'adb' });
+
+        Object.defineProperty(cp, 'execFile', {
+            value: (_file: string, _args: readonly string[], _options: cpTypes.ExecFileOptions, callback: (error: cpTypes.ExecException | null, stdout: string, stderr: string) => void) => {
+                callback(new Error('Command failed'), '', 'stderr output');
+                return {} as cpTypes.ChildProcess;
+            },
+            configurable: true
+        });
+
+        try {
+            await adbClient.execAdb(['devices'], {});
+            assert.fail('Should have thrown an error');
+        } catch (e: unknown) {
+            if (e instanceof Error) {
+                assert.strictEqual(e.message, 'Command failed (stderr: stderr output)');
+            } else {
+                assert.fail('Unexpected error type');
+            }
+        }
+    });
+
+    test('spawnAdb returns child process', () => {
+        // @ts-expect-error Mocking for test
+        vscode.workspace.getConfiguration = () => ({ get: () => 'adb' });
+
+        const mockChildProcess = { pid: 12345 } as cpTypes.ChildProcess;
+        Object.defineProperty(cp, 'spawn', {
+            value: (command: string, args: readonly string[], _options: cpTypes.SpawnOptions) => {
+                assert.strictEqual(command, 'adb');
+                assert.deepStrictEqual(args, ['logcat']);
+                return mockChildProcess;
+            },
+            configurable: true
+        });
+
+        const result = adbClient.spawnAdb(['logcat']);
+        assert.strictEqual(result.pid, 12345);
+    });
+});

--- a/src/test/services/AdbDeviceService.test.ts
+++ b/src/test/services/AdbDeviceService.test.ts
@@ -1,0 +1,109 @@
+import * as assert from 'assert';
+import { AdbDeviceService } from '../../services/adb/AdbDeviceService';
+import { AdbClient } from '../../services/adb/AdbClient';
+import { Logger } from '../../services/Logger';
+
+suite('AdbDeviceService Test Suite', () => {
+    let adbClient: AdbClient;
+    let logger: Logger;
+    let service: AdbDeviceService;
+
+    setup(() => {
+        logger = {
+            info: () => { },
+            warn: () => { },
+            error: () => { },
+            dispose: () => { }
+        } as unknown as Logger;
+
+        adbClient = {
+            getAdbPath: () => 'adb',
+            execAdb: async () => '',
+            spawnAdb: () => ({}) as unknown as import('child_process').ChildProcess
+        } as unknown as AdbClient;
+
+        service = new AdbDeviceService(logger, adbClient);
+    });
+
+    test('getDevices properly parses adb devices -l output', async () => {
+        adbClient.execAdb = async (args: string[]) => {
+            assert.deepStrictEqual(args, ['devices', '-l']);
+            return 'List of devices attached\n911X01B93    device product:blueline model:Pixel_3 device:blueline transport_id:1\nemulator-5554 offline\ndead-device unauthorized\n';
+        };
+
+        const devices = await service.getDevices();
+        assert.strictEqual(devices.length, 3);
+
+        assert.strictEqual(devices[0].id, '911X01B93');
+        assert.strictEqual(devices[0].type, 'device');
+        assert.strictEqual(devices[0].model, 'Pixel_3');
+        assert.strictEqual(devices[0].product, 'blueline');
+
+        assert.strictEqual(devices[1].id, 'emulator-5554');
+        assert.strictEqual(devices[1].type, 'offline');
+
+        assert.strictEqual(devices[2].id, 'dead-device');
+        assert.strictEqual(devices[2].type, 'unauthorized');
+    });
+
+    test('getDevices handles error gracefully', async () => {
+        adbClient.execAdb = async () => { throw new Error('Timeout'); };
+
+        const devices = await service.getDevices();
+        assert.strictEqual(devices.length, 0);
+    });
+
+    test('captureScreenshot handles success', async () => {
+        let pullCalled = false;
+        adbClient.execAdb = async (args) => {
+            if (args.includes('screencap')) { return ''; }
+            if (args.includes('pull')) { pullCalled = true; return ''; }
+            if (args.includes('rm')) { return ''; }
+            return '';
+        };
+
+        const result = await service.captureScreenshot('dev-1', '/local/path.png');
+        assert.strictEqual(result, true);
+        assert.strictEqual(pullCalled, true);
+    });
+
+    test('getSystemInfo parses various dumped outputs', async () => {
+        adbClient.execAdb = async (args) => {
+            const cmd = args.join(' ');
+            if (cmd.includes('getprop')) {
+                return '[ro.product.model]: [Test_Model]\n[ro.build.version.release]: [11]\n[ro.build.version.sdk]: [30]\n[ro.product.cpu.abi]: [arm64-v8a]';
+            }
+            if (cmd.includes('wm size')) { return 'Physical size: 1080x2340'; }
+            if (cmd.includes('wm density')) { return 'Physical density: 400'; }
+            if (cmd.includes('dumpsys window displays')) { return 'mBounds=[0,0][1080,2340]'; }
+            if (cmd.includes('dumpsys battery')) { return 'level: 85'; }
+            if (cmd.includes('cat /proc/meminfo')) { return 'MemTotal: 4000000 kB\nMemAvailable: 2000000 kB'; }
+            if (cmd.includes('ip route')) { return '192.168.1.0/24 dev wlan0 proto kernel scope link src 192.168.1.10'; }
+            if (cmd.includes('curl')) { return '8.8.8.8'; }
+            if (cmd.includes('df /data')) { return 'Filesystem 1K-blocks Used Available Use% Mounted on\n/dev/block 100000 50000 50000 50% /data'; }
+            if (cmd.includes('android_id')) { return 'beef1234'; }
+            return '';
+        };
+
+        const info = await service.getSystemInfo('device1');
+
+        assert.ok(info.includes('Model: Test_Model'));
+        assert.ok(info.includes('Android Version: 11 (SDK 30)'));
+        assert.ok(info.includes('CPU ABI: arm64-v8a'));
+        assert.ok(info.includes('Android ID: beef1234'));
+
+        // Display
+        assert.ok(info.includes('Resolution: 1080x2340, 400'));
+
+        // Battery
+        assert.ok(info.includes('Battery: 85%'));
+
+        // Network
+        assert.ok(info.includes('192.168.1.10 (wlan0)'));
+        assert.ok(info.includes('8.8.8.8 (via https://api.ipify.org)'));
+
+        // Mem and Disk
+        assert.ok(info.includes('Total 3906 MB'));
+        assert.ok(info.includes('Available 1953 MB'));
+    });
+});

--- a/src/test/services/AdbLogcatService.test.ts
+++ b/src/test/services/AdbLogcatService.test.ts
@@ -1,0 +1,94 @@
+import * as assert from 'assert';
+import { AdbLogcatService } from '../../services/adb/AdbLogcatService';
+import { AdbClient } from '../../services/adb/AdbClient';
+import { AdbTargetAppService } from '../../services/adb/AdbTargetAppService';
+import { Logger } from '../../services/Logger';
+import { AdbDevice, LogPriority } from '../../models/AdbModels';
+import * as cp from 'child_process';
+
+suite('AdbLogcatService Test Suite', () => {
+    let service: AdbLogcatService;
+    let logger: Logger;
+    let client: AdbClient;
+    let targetAppService: AdbTargetAppService;
+
+    setup(() => {
+        logger = {
+            info: () => { },
+            warn: () => { },
+            error: () => { },
+            dispose: () => { }
+        } as unknown as Logger;
+
+        client = {
+            getAdbPath: () => 'adb',
+            spawnAdb: () => ({
+                stdout: { on: () => { } },
+                stderr: { on: () => { } },
+                on: () => { },
+                kill: () => { }
+            } as unknown as cp.ChildProcess)
+        } as unknown as AdbClient;
+
+        targetAppService = {
+            getAppPid: async () => undefined
+        } as unknown as AdbTargetAppService;
+
+        service = new AdbLogcatService(logger, client, targetAppService);
+    });
+
+    test('createSession and getSession', () => {
+        const device: AdbDevice = { id: 'device1', type: 'device' };
+        const session = service.createSession('Test Session', device);
+
+        assert.ok(session.id);
+        assert.strictEqual(session.name, 'Test Session');
+        assert.strictEqual(session.device.id, 'device1');
+        assert.strictEqual(session.isRunning, false);
+        assert.strictEqual(session.useStartFromCurrentTime, true);
+
+        const retrieved = service.getSession(session.id);
+        assert.deepStrictEqual(retrieved, session);
+
+        const all = service.getSessions();
+        assert.strictEqual(all.length, 1);
+    });
+
+    test('removeSession', () => {
+        const device: AdbDevice = { id: 'device1', type: 'device' };
+        const session = service.createSession('Test Session', device);
+
+        service.removeSession(session.id);
+        assert.strictEqual(service.getSessions().length, 0);
+        assert.strictEqual(service.getSession(session.id), undefined);
+    });
+
+    test('tags management', () => {
+        const device: AdbDevice = { id: 'device1', type: 'device' };
+        const session = service.createSession('Test Session', device);
+
+        service.addTag(session.id, { id: 'tag1', name: 'TAG', priority: LogPriority.Debug, isEnabled: true });
+
+        let tags = service.getSession(session.id)!.tags;
+        assert.strictEqual(tags.length, 1);
+        assert.strictEqual(tags[0].name, 'TAG');
+
+        service.updateTag(session.id, { id: 'tag1', name: 'TAG2', priority: LogPriority.Info, isEnabled: false });
+        tags = service.getSession(session.id)!.tags;
+        assert.strictEqual(tags[0].name, 'TAG2');
+        assert.strictEqual(tags[0].isEnabled, false);
+
+        service.removeTag(session.id, 'tag1');
+        tags = service.getSession(session.id)!.tags;
+        assert.strictEqual(tags.length, 0);
+    });
+
+    test('toggleSessionTimeFilter', () => {
+        const device: AdbDevice = { id: 'device1', type: 'device' };
+        const session = service.createSession('Test Session', device);
+
+        assert.strictEqual(session.useStartFromCurrentTime, true);
+        service.toggleSessionTimeFilter(session.id);
+        assert.strictEqual(session.useStartFromCurrentTime, false);
+    });
+});

--- a/src/test/services/AdbTargetAppService.test.ts
+++ b/src/test/services/AdbTargetAppService.test.ts
@@ -1,0 +1,100 @@
+import * as assert from 'assert';
+import { AdbTargetAppService } from '../../services/adb/AdbTargetAppService';
+import { AdbClient } from '../../services/adb/AdbClient';
+import { Logger } from '../../services/Logger';
+import { AdbDevice } from '../../models/AdbModels';
+
+suite('AdbTargetAppService Test Suite', () => {
+    let service: AdbTargetAppService;
+    let logger: Logger;
+    let client: AdbClient;
+
+    setup(() => {
+        logger = {
+            info: () => { },
+            warn: () => { },
+            error: () => { },
+            dispose: () => { }
+        } as unknown as Logger;
+
+        client = {
+            getAdbPath: () => 'adb',
+            execAdb: async () => ''
+        } as unknown as AdbClient;
+
+        service = new AdbTargetAppService(logger, client);
+    });
+
+    test('manage target app map', () => {
+        const device: AdbDevice = { id: 'device1', type: 'device' };
+        service.setTargetApp(device, 'com.example.app');
+        assert.strictEqual(service.getTargetApp('device1'), 'com.example.app');
+        assert.strictEqual(device.targetApp, 'com.example.app');
+    });
+
+    test('getInstalledPackages', async () => {
+        client.execAdb = async (args) => {
+            if (args.includes('pm')) {
+                return 'package:com.android.calculator\npackage:com.example.app\nrandom extra line';
+            }
+            return '';
+        };
+
+        const packages = await service.getInstalledPackages('device1');
+        assert.deepStrictEqual(packages, ['com.android.calculator', 'com.example.app']);
+    });
+
+    test('getRunningApps parses ps output', async () => {
+        client.execAdb = async (args) => {
+            if (args.includes('ps')) {
+                return `USER PID PPID VSIZE RSS WCHAN PC NAME
+u0_a100 1234 567 10000 2000 0 0 com.example.app
+root 1 0 1000 100 0 0 init`;
+            }
+            return '';
+        };
+
+        const apps = await service.getRunningApps('device1');
+        assert.strictEqual(apps.has('com.example.app'), true);
+        assert.strictEqual(apps.has('init'), false); // no dot
+    });
+
+    test('getAppPid handles pidof', async () => {
+        client.execAdb = async (args) => {
+            if (args.includes('pidof')) {
+                return '12345\n';
+            }
+            return '';
+        };
+
+        const pid = await service.getAppPid('device1', 'com.example.app');
+        assert.strictEqual(pid, '12345');
+    });
+
+    test('app lifecycle helpers', async () => {
+        let lastArgs: string[] = [];
+        client.execAdb = async (args) => {
+            lastArgs = args as string[];
+            if (args.includes('uninstall')) {return 'Success';}
+            if (args.includes('clear')) {return 'Success';}
+            if (args.includes('monkey')) {return 'Events injected: 100';}
+            return '';
+        };
+
+        const uninstalled = await service.uninstallApp('dev1', 'com.app');
+        assert.ok(uninstalled);
+        assert.ok(lastArgs.includes('uninstall'));
+
+        const cleared = await service.clearAppStorage('dev1', 'com.app');
+        assert.ok(cleared);
+        assert.ok(lastArgs.includes('clear'));
+
+        const cached = await service.clearAppCache('dev1', 'com.app');
+        assert.ok(cached);
+        assert.ok(lastArgs.includes('run-as'));
+
+        const launched = await service.launchApp('dev1', 'com.app');
+        assert.ok(launched);
+        assert.ok(lastArgs.includes('monkey'));
+    });
+});

--- a/src/test/services/Disposal.test.ts
+++ b/src/test/services/Disposal.test.ts
@@ -1,0 +1,35 @@
+import * as assert from 'assert';
+import { AdbLogcatService } from '../../services/adb/AdbLogcatService';
+import { AdbService } from '../../services/AdbService';
+import { Logger } from '../../services/Logger';
+import { AdbClient } from '../../services/adb/AdbClient';
+import { AdbTargetAppService } from '../../services/adb/AdbTargetAppService';
+
+suite('Disposal Test Suite', () => {
+    let logger: Logger;
+
+    setup(() => {
+        logger = {
+            info: () => { },
+            warn: () => { },
+            error: () => { },
+            dispose: () => { }
+        } as unknown as Logger;
+    });
+
+    test('AdbLogcatService dispose does not throw', () => {
+        const client = {} as AdbClient;
+        const targetAppService = {} as AdbTargetAppService;
+        const service = new AdbLogcatService(logger, client, targetAppService);
+        assert.doesNotThrow(() => {
+            service.dispose();
+        });
+    });
+
+    test('AdbService dispose does not throw', () => {
+        const service = new AdbService(logger);
+        assert.doesNotThrow(() => {
+            service.dispose();
+        });
+    });
+});

--- a/src/test/views/JsonTreeWebview.test.ts
+++ b/src/test/views/JsonTreeWebview.test.ts
@@ -1,0 +1,111 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { JsonTreeWebview } from '../../views/JsonTreeWebview';
+import { JsonTreeHtmlGenerator } from '../../views/JsonTreeHtmlGenerator';
+import { MockExtensionContext } from '../utils/Mocks';
+
+suite('JsonTreeWebview Test Suite', () => {
+    let webview: JsonTreeWebview;
+    let mockContext: MockExtensionContext;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let originalGenerate: any;
+
+    setup(() => {
+        mockContext = new MockExtensionContext();
+        webview = new JsonTreeWebview(mockContext as unknown as vscode.ExtensionContext);
+
+        originalGenerate = JsonTreeHtmlGenerator.prototype.generate;
+        JsonTreeHtmlGenerator.prototype.generate = async () => '<html></html>';
+    });
+
+    teardown(() => {
+        webview.dispose();
+        JsonTreeHtmlGenerator.prototype.generate = originalGenerate;
+    });
+
+    test('show creates panel', async () => {
+        let panelCreated = false;
+
+        const mockPanel = {
+            webview: {
+                html: '',
+                onDidReceiveMessage: () => ({ dispose: () => { } }),
+                postMessage: async () => true
+            },
+            onDidDispose: () => ({ dispose: () => { } }),
+            reveal: () => { },
+            dispose: () => { }
+        } as unknown as vscode.WebviewPanel;
+
+        const originalCreateWebviewPanel = vscode.window.createWebviewPanel;
+        vscode.window.createWebviewPanel = () => {
+            panelCreated = true;
+            return mockPanel;
+        };
+
+        await webview.show({ key: 'value' });
+
+        vscode.window.createWebviewPanel = originalCreateWebviewPanel;
+
+        assert.strictEqual(panelCreated, true);
+        assert.strictEqual(webview.isVisible, true);
+    });
+
+    test('show reuses existing panel and posts message', async () => {
+        let postedMessage: { command?: string; data?: unknown } | undefined;
+        let revealed = false;
+
+        const mockPanel = {
+            webview: {
+                html: '',
+                onDidReceiveMessage: () => ({ dispose: () => { } }),
+                postMessage: async (msg: unknown) => {
+                    postedMessage = msg as { command?: string; data?: unknown };
+                    return true;
+                }
+            },
+            onDidDispose: () => ({ dispose: () => { } }),
+            reveal: () => { revealed = true; },
+            dispose: () => { }
+        } as unknown as vscode.WebviewPanel;
+
+        const originalCreateWebviewPanel = vscode.window.createWebviewPanel;
+        vscode.window.createWebviewPanel = () => mockPanel;
+
+        // First call creates panel
+        await webview.show({ key1: 'value1' });
+        // Second call reuses it
+        await webview.show({ key2: 'value2' });
+
+        vscode.window.createWebviewPanel = originalCreateWebviewPanel;
+
+        assert.strictEqual(revealed, true);
+        assert.ok(postedMessage);
+        assert.deepStrictEqual(postedMessage.data, { key2: 'value2' });
+        assert.strictEqual(postedMessage.command, 'update');
+    });
+
+    test('dispose clears panel', async () => {
+        const mockPanel = {
+            webview: {
+                html: '',
+                onDidReceiveMessage: () => ({ dispose: () => { } }),
+                postMessage: async () => true
+            },
+            onDidDispose: () => ({ dispose: () => { } }),
+            reveal: () => { },
+            dispose: () => { }
+        } as unknown as vscode.WebviewPanel;
+
+        const originalCreateWebviewPanel = vscode.window.createWebviewPanel;
+        vscode.window.createWebviewPanel = () => mockPanel;
+
+        await webview.show({ key: 'value' });
+        assert.strictEqual(webview.isVisible, true);
+
+        webview.dispose();
+        assert.strictEqual(webview.isVisible, false);
+
+        vscode.window.createWebviewPanel = originalCreateWebviewPanel;
+    });
+});

--- a/src/test/views/LogBookmarkWebviewProvider.test.ts
+++ b/src/test/views/LogBookmarkWebviewProvider.test.ts
@@ -1,0 +1,64 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { LogBookmarkWebviewProvider } from '../../views/LogBookmarkWebviewProvider';
+import { LogBookmarkService } from '../../services/LogBookmarkService';
+import { Logger } from '../../services/Logger';
+import { MockExtensionContext } from '../utils/Mocks';
+
+suite('LogBookmarkWebviewProvider Test Suite', () => {
+    let provider: LogBookmarkWebviewProvider;
+    let bookmarkService: LogBookmarkService;
+    let logger: Logger;
+    let mockContext: MockExtensionContext;
+
+    setup(() => {
+        mockContext = new MockExtensionContext();
+        logger = {
+            error: () => { },
+            info: () => { },
+            warn: () => { },
+            debug: () => { },
+            dispose: () => { }
+        } as unknown as Logger;
+
+        bookmarkService = new LogBookmarkService(mockContext as unknown as vscode.ExtensionContext);
+
+        provider = new LogBookmarkWebviewProvider(
+            vscode.Uri.file('/mock/ext'),
+            bookmarkService,
+            logger
+        );
+    });
+
+    teardown(() => {
+        provider.dispose();
+        bookmarkService.dispose();
+    });
+
+    test('resolveWebviewView sets up webview', () => {
+        let listenerRegistered = false;
+        const mockWebviewView = {
+            webview: {
+                options: {},
+                onDidReceiveMessage: (_listener: unknown) => {
+                    listenerRegistered = true;
+                },
+                html: ''
+            }
+        } as unknown as vscode.WebviewView;
+
+        provider.resolveWebviewView(
+            mockWebviewView,
+            {} as vscode.WebviewViewResolveContext,
+            {} as vscode.CancellationToken
+        );
+
+        assert.strictEqual(listenerRegistered, true, 'Message listener should be registered');
+    });
+
+    test('dispose cleans up resources', () => {
+        assert.doesNotThrow(() => {
+            provider.dispose();
+        });
+    });
+});

--- a/src/test/views/WorkflowWebviewProvider.test.ts
+++ b/src/test/views/WorkflowWebviewProvider.test.ts
@@ -1,0 +1,91 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { WorkflowWebviewProvider } from '../../views/WorkflowWebviewProvider';
+import { WorkflowManager } from '../../services/WorkflowManager';
+import { WorkflowHtmlGenerator } from '../../views/WorkflowHtmlGenerator';
+import { MockExtensionContext } from '../utils/Mocks';
+
+suite('WorkflowWebviewProvider Test Suite', () => {
+    let provider: WorkflowWebviewProvider;
+    let mockContext: MockExtensionContext;
+    let mockWorkflowManager: WorkflowManager;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let originalGenerate: any;
+
+    setup(() => {
+        mockContext = new MockExtensionContext();
+        mockWorkflowManager = {
+            getWorkflowViewModels: async () => [],
+            getActiveWorkflow: () => undefined,
+            getActiveStep: () => undefined,
+            onDidChangeWorkflow: () => ({ dispose: () => { } })
+        } as unknown as WorkflowManager;
+
+        provider = new WorkflowWebviewProvider(
+            mockContext as unknown as vscode.ExtensionContext,
+            mockWorkflowManager
+        );
+
+        originalGenerate = WorkflowHtmlGenerator.prototype.generate;
+        WorkflowHtmlGenerator.prototype.generate = async () => '<html></html>';
+    });
+
+    teardown(() => {
+        WorkflowHtmlGenerator.prototype.generate = originalGenerate;
+    });
+
+    test('resolveWebviewView sets up webview', async () => {
+        let listenerRegistered = false;
+        let htmlSet = false;
+
+        const mockWebviewView = {
+            webview: {
+                options: {},
+                onDidReceiveMessage: (_listener: unknown) => {
+                    listenerRegistered = true;
+                },
+                set html(_value: string) {
+                    htmlSet = true;
+                }
+            },
+            onDidChangeVisibility: () => ({ dispose: () => { } }),
+            onDidDispose: () => ({ dispose: () => { } })
+        } as unknown as vscode.WebviewView;
+
+        await provider.resolveWebviewView(
+            mockWebviewView,
+            {} as vscode.WebviewViewResolveContext,
+            {} as vscode.CancellationToken
+        );
+
+        assert.strictEqual(listenerRegistered, true, 'Message listener should be registered');
+        assert.strictEqual(htmlSet, true, 'HTML should be set');
+    });
+
+    test('refresh posts update message', async () => {
+        let postedMessage: { type?: string } | undefined;
+        const mockWebviewView = {
+            webview: {
+                options: {},
+                onDidReceiveMessage: () => { },
+                html: '',
+                postMessage: async (msg: unknown) => {
+                    postedMessage = msg as { type?: string };
+                }
+            },
+            onDidChangeVisibility: () => ({ dispose: () => { } }),
+            onDidDispose: () => ({ dispose: () => { } })
+        } as unknown as vscode.WebviewView;
+
+        await provider.resolveWebviewView(
+            mockWebviewView,
+            {} as vscode.WebviewViewResolveContext,
+            {} as vscode.CancellationToken
+        );
+
+        await provider.refresh();
+
+        assert.ok(postedMessage);
+        assert.strictEqual(postedMessage.type, 'update');
+    });
+});


### PR DESCRIPTION
Add tests for various core components to address Code Review section 3.1 'Missing Test Coverage'.

1. ADB Services: Added coverage for AdbClient, AdbDeviceService, AdbLogcatService, and AdbTargetAppService.
2. Webview Providers: Implemented tests for JsonTreeWebview, LogBookmarkWebviewProvider, and WorkflowWebviewProvider. Handled FileSystemError exceptions by securely mocking the HTML generators.
3. Command Managers: Added tests for AdbCommandManager, EditorToggleCommandManager, and NavigationCommandManager.
4. Disposal: Added Disposal.test.ts to verify proper cleanup.

Fixed test contamination issues and strict mode TypeError mocking issues (e.g., using Object.defineProperty for getter-only properties in child_process and modifying module aliases). Ensures all test suites pass flawlessly without leaks.