### PR TITLE
fix: implement Disposable for AdbDeviceTreeProvider and minor cleanup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -147,7 +147,7 @@ export function activate(context: vscode.ExtensionContext) {
     const adbService = new AdbService(logger);
     context.subscriptions.push(adbService);
     const adbDeviceTreeProvider = new AdbDeviceTreeProvider(adbService);
-    // vscode.window.registerTreeDataProvider(Constants.Views.ADBDevices, adbDeviceTreeProvider);
+    context.subscriptions.push(adbDeviceTreeProvider);
     const adbTreeView = vscode.window.createTreeView(Constants.Views.ADBDevices, {
         treeDataProvider: adbDeviceTreeProvider,
         showCollapseAll: true


### PR DESCRIPTION
- Implement vscode.Disposable interface, track onDidChangeSessions subscription in _disposables array, and dispose EventEmitter
- Register adbDeviceTreeProvider in context.subscriptions
- Remove unreachable duplicate return statement in showTouches branch
- Add try-catch for getShowTouchesState in getChildren to prevent tree from silently failing on error