### PR TITLE
Potential fix for code scanning alert no. 3: Exception text reinterpreted as HTML

### DIFF
--- a/resources/webview/workflow-tree-template.html
+++ b/resources/webview/workflow-tree-template.html
@@ -550,7 +550,12 @@
                     container.appendChild(el);
                 });
             } catch (err) {
-                container.innerHTML = '<div style="color:red; padding:10px;">Error rendering workflow: ' + err + '</div>';
+                const errorDiv = document.createElement('div');
+                errorDiv.style.color = 'red';
+                errorDiv.style.padding = '10px';
+                errorDiv.textContent = 'Error rendering workflow: ' + String(err);
+                container.innerHTML = '';
+                container.appendChild(errorDiv);
             }
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/webispy/vscode-logmagnifier/security/code-scanning/3](https://github.com/webispy/vscode-logmagnifier/security/code-scanning/3)

In general, the issue is that exception text (which may include attacker-controlled content) is being inserted into the DOM via `innerHTML`, where it will be parsed as HTML. The fix is to ensure that any error message is treated as plain text. This can be done by: (a) not using `innerHTML` for dynamic content that may contain user input; (b) when an HTML wrapper is needed, create a safe container element and assign the untrusted portion to `textContent` or `innerText`, or apply proper HTML-encoding before concatenation.

The best minimal fix here is to replace the single `innerHTML` assignment in the `catch` block with code that creates a `<div>` element, sets its style (or class) safely, and assigns the error text to `textContent`. That way, however `err` is derived (string, `Error` object, custom object), its textual representation is never interpreted as markup. Concretely in `resources/webview/workflow-tree-template.html`, lines 552–553 should be updated: instead of building an HTML string containing `err` and assigning it via `innerHTML`, create a `div`, apply the same inline styles via `el.style.*`, and set `el.textContent = 'Error rendering workflow: ' + err;` (or a safer conversion like `String(err)`). Then replace the container contents with that `div` by clearing `container.innerHTML` and appending the element via `appendChild`. No new imports or external libraries are needed; all used APIs are standard DOM methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
