### PR TITLE
security: fix XSS in runbook webview and add Content Security Policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "logmagnifier",
       "version": "1.6.2",
       "dependencies": {
-        "marked": "^8.0.1"
+        "marked": "^8.0.1",
+        "sanitize-html": "^2.17.1"
       },
       "devDependencies": {
         "@types/marked": "^5.0.1",
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",
+        "@types/sanitize-html": "^2.16.0",
         "@types/vscode": "^1.94.0",
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.5.2",
@@ -389,6 +391,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.0.tgz",
+      "integrity": "sha512-l6rX1MUXje5ztPT0cAFtUayXF06DqPhRyfVXareEN5gGCFaP/iwsxIyKODr9XDhfxPpN6vXUFNfo5kZMXCxBtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^8.0.0"
       }
     },
     "node_modules/@types/vscode": {
@@ -1132,6 +1144,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/diff": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
@@ -1140,6 +1161,61 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/eastasianwidth": {
@@ -1170,6 +1246,18 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1184,7 +1272,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1615,6 +1702,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -1781,6 +1887,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -2163,6 +2278,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2378,6 +2511,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2419,7 +2558,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -2433,6 +2571,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -2545,6 +2711,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sanitize-html": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.1.tgz",
+      "integrity": "sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -2609,6 +2789,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/stdin-discarder": {

--- a/package.json
+++ b/package.json
@@ -1805,6 +1805,7 @@
     "@types/marked": "^5.0.1",
     "@types/mocha": "^10.0.10",
     "@types/node": "22.x",
+    "@types/sanitize-html": "^2.16.0",
     "@types/vscode": "^1.94.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.5.2",
@@ -1813,6 +1814,7 @@
     "typescript-eslint": "^8.48.1"
   },
   "dependencies": {
-    "marked": "^8.0.1"
+    "marked": "^8.0.1",
+    "sanitize-html": "^2.17.1"
   }
 }

--- a/resources/webview/runbook-template.html
+++ b/resources/webview/runbook-template.html
@@ -4,7 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- Relaxed CSP for inline execution -->
+    <meta http-equiv="Content-Security-Policy"
+        content="default-src 'none'; style-src {{ CSP_SOURCE }} 'unsafe-inline'; script-src 'nonce-{{ NONCE }}'; font-src {{ CSP_SOURCE }};">
     <title>{{ TITLE }}</title>
     <link href="{{ CODICON_CSS_URI }}" rel="stylesheet" />
     <style>
@@ -100,16 +101,27 @@
 
 <body>
     {{ HTML_CONTENT }}
-    <script>
+    <script nonce="{{ NONCE }}">
         const vscode = acquireVsCodeApi();
 
-        function executeBlock(blockId, script) {
-            vscode.postMessage({
-                command: 'execute',
-                blockId: blockId,
-                script: script
-            });
-        }
+        // Script map injected from RunbookHtmlGenerator (avoids inline onclick handlers)
+        const scriptMap = {{ SCRIPT_MAP }};
+
+        // Event delegation for play buttons
+        document.body.addEventListener('click', event => {
+            const btn = event.target.closest('.play-btn[data-block-id]');
+            if (!btn || btn.disabled) return;
+
+            const blockId = btn.getAttribute('data-block-id');
+            const script = scriptMap[blockId];
+            if (blockId && script !== undefined) {
+                vscode.postMessage({
+                    command: 'execute',
+                    blockId: blockId,
+                    script: script
+                });
+            }
+        });
 
         window.addEventListener('message', event => {
             const message = event.data;

--- a/src/views/RunbookHtmlGenerator.ts
+++ b/src/views/RunbookHtmlGenerator.ts
@@ -4,10 +4,23 @@ import { Logger } from '../services/Logger';
 import * as marked from 'marked';
 import * as fs from 'fs';
 import * as path from 'path';
-import { getNonce } from '../utils/WebviewUtils';
+import { getNonce, escapeHtml } from '../utils/WebviewUtils';
+import sanitizeHtmlLib from 'sanitize-html';
 
 export class RunbookHtmlGenerator {
     constructor(private readonly context: vscode.ExtensionContext) { }
+
+    /**
+     * Sanitize HTML output from marked to prevent XSS.
+     * Uses the well-tested `sanitize-html` library to strip <script> tags,
+     * on* event handler attributes, and other unsafe constructs that could be
+     * injected via malicious markdown content.
+     */
+    private sanitizeHtml(html: string): string {
+        // Rely on sanitize-html defaults, which already remove script tags,
+        // event handler attributes (on*), and other potentially dangerous markup.
+        return sanitizeHtmlLib(html);
+    }
 
     public async generate(webview: vscode.Webview, item: RunbookMarkdown): Promise<string> {
         let content = '';
@@ -18,6 +31,9 @@ export class RunbookHtmlGenerator {
             content = `# Error\nCould not read file: ${item.filePath}`;
         }
 
+        // Collect scripts for injection via nonce'd script block (not inline handlers)
+        const scriptMap: Map<string, string> = new Map();
+
         // Custom Renderer to inject Play buttons into `sh` blocks
         const renderer = new marked.Renderer();
         let blockIndex = 0;
@@ -27,32 +43,36 @@ export class RunbookHtmlGenerator {
             const lang = typeof code === 'string' ? language : code.lang;
             if (lang === 'sh' || lang === 'bash' || lang === 'shell') {
                 const currentBlockId = `block_${blockIndex++}`;
-                // Keep the script intact for execution
-                const escapedScript = text.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+                // Store script for event delegation (avoids inline onclick)
+                scriptMap.set(currentBlockId, text);
 
                 return `
                 <div class="code-block-container" id="${currentBlockId}">
                     <div class="code-block-header">
                         <span class="lang-label">sh</span>
-                        <vscode-button appearance="secondary" class="play-btn" id="btn_${currentBlockId}" onclick="executeBlock('${currentBlockId}', \`${escapedScript}\`)">
+                        <button class="play-btn" id="btn_${currentBlockId}" data-block-id="${currentBlockId}">
                             <span class="codicon codicon-play"></span> Play
-                        </vscode-button>
+                        </button>
                     </div>
-                    <pre><code class="language-${lang}">${text}</code></pre>
+                    <pre><code class="language-${escapeHtml(lang)}">${escapeHtml(text)}</code></pre>
                     <div class="output-container" id="output_${currentBlockId}" style="display: none;">
                         <pre><code></code></pre>
                     </div>
                 </div>
                 `;
             }
-            return `<pre><code>${text}</code></pre>`;
+            return `<pre><code>${escapeHtml(text)}</code></pre>`;
         };
 
         const markedOptions = {
             renderer: renderer
         };
 
-        const htmlContent = await marked.parse(content, markedOptions);
+        const rawHtmlContent = await marked.parse(content, markedOptions);
+        const htmlContent = this.sanitizeHtml(rawHtmlContent);
+
+        // Build JSON script map for the template
+        const scriptMapJson = JSON.stringify(Object.fromEntries(scriptMap));
 
         const templatePath = vscode.Uri.file(
             path.join(this.context.extensionPath, 'resources', 'webview', 'runbook-template.html')
@@ -75,6 +95,7 @@ export class RunbookHtmlGenerator {
         html = html.replace(/{{ NONCE }}/g, nonce);
         html = html.replace(/{{ CODICON_CSS_URI }}/g, codiconCssUri);
         html = html.replace(/{{ HTML_CONTENT }}/g, htmlContent);
+        html = html.replace(/{{ SCRIPT_MAP }}/g, scriptMapJson);
 
         return html;
     }


### PR DESCRIPTION
- Add CSP meta tag to runbook-template.html (matching other webview templates), restricting scripts to nonce-based execution only
- Sanitize marked HTML output by stripping <script> tags and on* event handler attributes from rendered markdown
- Replace inline onclick handlers with data attributes and event delegation to comply with the CSP
- Escape code block content with escapeHtml() to prevent HTML injection
- Store shell scripts in a JSON map injected via nonce'd script block instead of embedding them in inline onclick attributes