### PR TITLE
runbook: implement import/export feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1154,6 +1154,16 @@
         "icon": "$(edit)"
       },
       {
+        "command": "logmagnifier.runbook.export",
+        "title": "Export Runbook",
+        "icon": "$(repo-push)"
+      },
+      {
+        "command": "logmagnifier.runbook.import",
+        "title": "Import Runbook",
+        "icon": "$(repo-pull)"
+      },
+      {
         "command": "logmagnifier.hierarchy.showFullTree",
         "title": "Show Full Navigation Tree",
         "category": "LogMagnifier"
@@ -1408,14 +1418,24 @@
           "group": "navigation@3"
         },
         {
-          "command": "logmagnifier.runbook.addGroup",
+          "command": "logmagnifier.runbook.export",
           "when": "view == logmagnifier-runbook",
           "group": "navigation@1"
         },
         {
-          "command": "logmagnifier.runbook.addItem",
+          "command": "logmagnifier.runbook.import",
           "when": "view == logmagnifier-runbook",
           "group": "navigation@2"
+        },
+        {
+          "command": "logmagnifier.runbook.addGroup",
+          "when": "view == logmagnifier-runbook",
+          "group": "navigation@3"
+        },
+        {
+          "command": "logmagnifier.runbook.addItem",
+          "when": "view == logmagnifier-runbook",
+          "group": "navigation@4"
         }
       ],
       "editor/context": [

--- a/src/commands/RunbookCommandManager.ts
+++ b/src/commands/RunbookCommandManager.ts
@@ -4,6 +4,9 @@ import { Constants } from '../Constants';
 import { RunbookItem, RunbookMarkdown, RunbookGroup } from '../models/Runbook';
 import { Logger } from '../services/Logger';
 import { RunbookWebviewPanel } from '../views/RunbookWebviewPanel';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
 
 export class RunbookCommandManager {
     constructor(
@@ -23,6 +26,8 @@ export class RunbookCommandManager {
             vscode.commands.registerCommand(Constants.Commands.RunbookDeleteItem, this.deleteItem, this),
             vscode.commands.registerCommand(Constants.Commands.RunbookRenameGroup, this.renameItem, this),
             vscode.commands.registerCommand(Constants.Commands.RunbookRenameItem, this.renameItem, this),
+            vscode.commands.registerCommand(Constants.Commands.RunbookExport, this.exportRunbook, this),
+            vscode.commands.registerCommand(Constants.Commands.RunbookImport, this.importRunbook, this),
             vscode.commands.registerCommand(Constants.Commands.RefreshRunbookView, this.refreshRunbookView, this)
         );
     }
@@ -90,5 +95,50 @@ export class RunbookCommandManager {
 
     private async refreshRunbookView() {
         await this.runbookService.refresh();
+    }
+
+    private async exportRunbook() {
+        const fileName = 'logmagnifier_runbook.json';
+        const downloadsPath = path.join(os.homedir(), 'Downloads');
+        let defaultUri = vscode.Uri.file(path.join(downloadsPath, fileName));
+
+        // Fallback to homedir if Downloads doesn't exist
+        if (!fs.existsSync(downloadsPath)) {
+            defaultUri = vscode.Uri.file(path.join(os.homedir(), fileName));
+        }
+
+        const uri = await vscode.window.showSaveDialog({
+            defaultUri: defaultUri,
+            filters: {
+                'JSON Files': ['json']
+            },
+            title: 'Export Runbook'
+        });
+
+        if (uri) {
+            await this.runbookService.exportRunbook(uri);
+        }
+    }
+
+    private async importRunbook() {
+        const downloadsPath = path.join(os.homedir(), 'Downloads');
+        let defaultUri = vscode.Uri.file(downloadsPath);
+
+        if (!fs.existsSync(downloadsPath)) {
+            defaultUri = vscode.Uri.file(os.homedir());
+        }
+
+        const uris = await vscode.window.showOpenDialog({
+            defaultUri: defaultUri,
+            canSelectMany: false,
+            filters: {
+                'JSON Files': ['json']
+            },
+            title: 'Import Runbook'
+        });
+
+        if (uris && uris.length > 0) {
+            await this.runbookService.importRunbook(uris[0]);
+        }
     }
 }

--- a/src/constants/Ids.ts
+++ b/src/constants/Ids.ts
@@ -206,6 +206,8 @@ export const Ids = {
         RunbookDeleteItem: 'logmagnifier.runbook.deleteItem',
         RunbookRenameGroup: 'logmagnifier.runbook.renameGroup',
         RunbookRenameItem: 'logmagnifier.runbook.renameItem',
+        RunbookExport: 'logmagnifier.runbook.export',
+        RunbookImport: 'logmagnifier.runbook.import',
         RefreshRunbookView: 'logmagnifier.refreshRunbookView',
     },
 

--- a/src/services/RunbookService.ts
+++ b/src/services/RunbookService.ts
@@ -4,6 +4,13 @@ import * as path from 'path';
 import { RunbookItem, RunbookMarkdown, RunbookGroup } from '../models/Runbook';
 import { Logger } from './Logger';
 
+interface ExportedRunbookItem {
+    type: 'group' | 'markdown';
+    name: string;
+    content?: string;
+    children?: ExportedRunbookItem[];
+}
+
 export class RunbookService {
     private _items: RunbookItem[] = [];
     private _onDidChangeTreeData: vscode.EventEmitter<RunbookItem | undefined | null | void> = new vscode.EventEmitter<RunbookItem | undefined | null | void>();
@@ -137,6 +144,88 @@ adb exec-out screencap -p > screen.png
         if (fs.existsSync(targetPath)) {
             fs.rmSync(targetPath, { recursive: true, force: true });
             await this.refresh();
+        }
+    }
+
+    public async exportRunbook(targetUri: vscode.Uri): Promise<void> {
+        try {
+            const exportedItems = this.serializeItems(this._items);
+            const exportData = {
+                version: this.context.extension.packageJSON.version,
+                runbooks: exportedItems
+            };
+            const jsonString = JSON.stringify(exportData, null, 2);
+            await vscode.workspace.fs.writeFile(targetUri, Buffer.from(jsonString, 'utf-8'));
+            vscode.window.showInformationMessage('Runbook exported successfully!');
+        } catch (e) {
+            Logger.getInstance().error(`Failed to export runbook: ${e}`);
+            vscode.window.showErrorMessage(`Failed to export runbook: ${e}`);
+        }
+    }
+
+    private serializeItems(items: RunbookItem[]): ExportedRunbookItem[] {
+        return items.map(item => {
+            if (item.kind === 'group') {
+                return {
+                    type: 'group',
+                    name: item.label,
+                    children: this.serializeItems((item as RunbookGroup).children)
+                };
+            } else {
+                return {
+                    type: 'markdown',
+                    name: item.label,
+                    content: fs.readFileSync((item as RunbookMarkdown).filePath, 'utf-8')
+                };
+            }
+        });
+    }
+
+    public async importRunbook(sourceUri: vscode.Uri): Promise<void> {
+        try {
+            const fileData = await vscode.workspace.fs.readFile(sourceUri);
+            const jsonString = Buffer.from(fileData).toString('utf-8');
+            const parsedData = JSON.parse(jsonString);
+
+            let importedItems: ExportedRunbookItem[] = [];
+
+            if (typeof parsedData === 'object' && parsedData !== null && Array.isArray(parsedData.runbooks)) {
+                // New format with version wrapper
+                importedItems = parsedData.runbooks;
+                Logger.getInstance().info(`Importing runbook from JSON (File Version: ${parsedData.version || 'unknown'}).`);
+            } else {
+                throw new Error("Invalid runbook file format.");
+            }
+
+            await this.deserializeItems(importedItems, this.storagePath);
+            await this.refresh();
+            vscode.window.showInformationMessage('Runbook imported successfully!');
+        } catch (e) {
+            Logger.getInstance().error(`Failed to import runbook: ${e}`);
+            vscode.window.showErrorMessage(`Failed to import runbook: ${e}`);
+        }
+    }
+
+    private async deserializeItems(items: ExportedRunbookItem[], currentPath: string): Promise<void> {
+        if (!Array.isArray(items)) { return; }
+
+        for (const item of items) {
+            if (!item || !item.type || !item.name) { continue; }
+
+            if (item.type === 'group') {
+                const groupPath = path.join(currentPath, item.name);
+                if (!fs.existsSync(groupPath)) {
+                    fs.mkdirSync(groupPath, { recursive: true });
+                }
+                if (item.children) {
+                    await this.deserializeItems(item.children, groupPath);
+                }
+            } else if (item.type === 'markdown') {
+                const fileName = item.name.endsWith('.md') ? item.name : item.name + '.md';
+                const filePath = path.join(currentPath, fileName);
+                const content = item.content || '';
+                fs.writeFileSync(filePath, content, 'utf-8');
+            }
         }
     }
 }


### PR DESCRIPTION
Add JSON-based import and export capabilities to the Runbook view. This allows users to backup and share their runbook configurations.

Key features:
- Export runbook groups and items to logmagnifier_runbook.json
- Import runbook configurations from JSON format
- Merge imported configurations with existing ones
- Include extension version in the exported JSON file
- Set default directory for file dialogs to the user's Downloads folder