### PR TITLE
feat: add LogMagnifier category to palette commands and hide internal ones

### DIFF
--- a/package.json
+++ b/package.json
@@ -512,12 +512,14 @@
       {
         "command": "logmagnifier.addFilterGroup",
         "title": "Add Word Filter Group",
+        "category": "LogMagnifier",
         "description": "Create a new group to organize word filters",
         "icon": "$(new-folder)"
       },
       {
         "command": "logmagnifier.addRegexFilterGroup",
         "title": "Add Regex Filter Group",
+        "category": "LogMagnifier",
         "icon": "$(new-folder)"
       },
       {
@@ -538,11 +540,13 @@
       {
         "command": "logmagnifier.applyWordFilter",
         "title": "Apply Word Filter",
+        "category": "LogMagnifier",
         "icon": "$(run-all)"
       },
       {
         "command": "logmagnifier.applyRegexFilter",
         "title": "Apply Regex Filter",
+        "category": "LogMagnifier",
         "icon": "$(run-all)"
       },
       {
@@ -552,27 +556,32 @@
       },
       {
         "command": "logmagnifier.clearAllData",
-        "title": "LogMagnifier: Clear All Persistent Data",
+        "title": "Clear All Persistent Data",
+        "category": "LogMagnifier",
         "icon": "$(trash)"
       },
       {
         "command": "logmagnifier.clearFilterData",
-        "title": "LogMagnifier: Clear Filter Data",
+        "title": "Clear Filter Data",
+        "category": "LogMagnifier",
         "icon": "$(trash)"
       },
       {
         "command": "logmagnifier.clearBookmarkData",
-        "title": "LogMagnifier: Clear Bookmark Data",
+        "title": "Clear Bookmark Data",
+        "category": "LogMagnifier",
         "icon": "$(trash)"
       },
       {
         "command": "logmagnifier.clearWorkflowData",
-        "title": "LogMagnifier: Clear Workflow Data",
+        "title": "Clear Workflow Data",
+        "category": "LogMagnifier",
         "icon": "$(trash)"
       },
       {
         "command": "logmagnifier.clearRunbookData",
-        "title": "LogMagnifier: Clear Runbook Data",
+        "title": "Clear Runbook Data",
+        "category": "LogMagnifier",
         "icon": "$(trash)"
       },
       {
@@ -739,11 +748,13 @@
       {
         "command": "logmagnifier.previousMatch",
         "title": "Previous Match",
+        "category": "LogMagnifier",
         "icon": "$(arrow-up)"
       },
       {
         "command": "logmagnifier.nextMatch",
         "title": "Next Match",
+        "category": "LogMagnifier",
         "icon": "$(arrow-down)"
       },
       {
@@ -791,41 +802,54 @@
       {
         "command": "logmagnifier.toggleWordWrap",
         "title": "Toggle Word Wrap",
+        "category": "LogMagnifier",
         "icon": "$(word-wrap)"
       },
       {
         "command": "logmagnifier.toggleMinimap",
         "title": "Toggle Minimap",
+        "category": "LogMagnifier",
         "icon": "$(layout-sidebar-right)"
       },
       {
         "command": "logmagnifier.toggleStickyScroll",
         "title": "Toggle Sticky Scroll",
+        "category": "LogMagnifier",
         "icon": "$(pinned)"
       },
       {
         "command": "logmagnifier.toggleOccurrencesHighlight",
         "title": "Set Occurrences Highlight",
+        "category": "LogMagnifier",
         "icon": "$(search)"
+      },
+      {
+        "command": "logmagnifier.toggleFileSizeUnit",
+        "title": "Toggle File Size Unit",
+        "icon": "$(file-binary)"
       },
       {
         "command": "logmagnifier.toggleJsonPreview",
         "title": "Toggle Auto JSON Preview",
+        "category": "LogMagnifier",
         "icon": "$(json)"
       },
       {
         "command": "logmagnifier.exportWordFilters",
         "title": "Export Word Filters",
+        "category": "LogMagnifier",
         "icon": "$(repo-push)"
       },
       {
         "command": "logmagnifier.removeAllBookmarks",
         "title": "Remove All Bookmarks",
+        "category": "LogMagnifier",
         "icon": "$(trash)"
       },
       {
         "command": "logmagnifier.importWordFilters",
         "title": "Import Word Filters",
+        "category": "LogMagnifier",
         "icon": "$(repo-pull)"
       },
       {
@@ -895,6 +919,7 @@
       {
         "command": "logmagnifier.exportRegexFilters",
         "title": "Export Regex Filters",
+        "category": "LogMagnifier",
         "icon": "$(repo-push)"
       },
       {
@@ -905,11 +930,13 @@
       {
         "command": "logmagnifier.importRegexFilters",
         "title": "Import Regex Filters",
+        "category": "LogMagnifier",
         "icon": "$(repo-pull)"
       },
       {
         "command": "logmagnifier.addSelectionToFilter",
         "title": "Add Selection to Word Filter",
+        "category": "LogMagnifier",
         "icon": "$(plus)"
       },
       {
@@ -935,6 +962,7 @@
       {
         "command": "logmagnifier.jumpToSource",
         "title": "Jump to Original Log Line",
+        "category": "LogMagnifier",
         "icon": "$(go-to-file)"
       },
       {
@@ -950,6 +978,7 @@
       {
         "command": "logmagnifier.manageProfiles",
         "title": "Filter Profiles...",
+        "category": "LogMagnifier",
         "icon": "$(book)"
       },
       {
@@ -999,11 +1028,12 @@
       },
       {
         "command": "logmagnifier.addBookmark",
-        "title": "Add Line to Bookmark"
+        "title": "Add Line to Bookmark",
+        "category": "LogMagnifier"
       },
       {
         "command": "logmagnifier.addMatchListToBookmark",
-        "title": "Add matches to bookmark",
+        "title": "Add Filter Matches to Bookmark",
         "icon": "$(bookmark)"
       },
       {
@@ -1066,7 +1096,8 @@
       },
       {
         "command": "logmagnifier.addSelectionMatchesToBookmark",
-        "title": "Add Matches to Bookmark",
+        "title": "Add Selection Matches to Bookmark",
+        "category": "LogMagnifier",
         "icon": "$(bookmark)"
       },
       {
@@ -1092,6 +1123,7 @@
       {
         "command": "logmagnifier.removeMatchesWithSelection",
         "title": "Remove Lines Matching Selection",
+        "category": "LogMagnifier",
         "icon": "$(trash)"
       },
       {
@@ -1126,16 +1158,19 @@
       {
         "command": "logmagnifier.workflow.export",
         "title": "Export Workflow",
+        "category": "LogMagnifier",
         "icon": "$(repo-push)"
       },
       {
         "command": "logmagnifier.workflow.import",
         "title": "Import Workflow",
+        "category": "LogMagnifier",
         "icon": "$(repo-pull)"
       },
       {
         "command": "logmagnifier.workflow.create",
         "title": "New Workflow",
+        "category": "LogMagnifier",
         "icon": "$(plus)"
       },
       {
@@ -1176,11 +1211,13 @@
       {
         "command": "logmagnifier.runbook.export",
         "title": "Export Runbook",
+        "category": "LogMagnifier",
         "icon": "$(repo-push)"
       },
       {
         "command": "logmagnifier.runbook.import",
         "title": "Import Runbook",
+        "category": "LogMagnifier",
         "icon": "$(repo-pull)"
       },
       {
@@ -1220,6 +1257,110 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        { "command": "logmagnifier.addMatchListToBookmark", "when": "false" },
+        { "command": "logmagnifier.addFilter", "when": "false" },
+        { "command": "logmagnifier.addRegexFilter", "when": "false" },
+        { "command": "logmagnifier.runFilterGroup", "when": "false" },
+        { "command": "logmagnifier.deleteFilter", "when": "false" },
+        { "command": "logmagnifier.enableGroup", "when": "false" },
+        { "command": "logmagnifier.disableGroup", "when": "false" },
+        { "command": "logmagnifier.enableFilter", "when": "false" },
+        { "command": "logmagnifier.disableFilter", "when": "false" },
+        { "command": "logmagnifier.enableAllItemsInGroup", "when": "false" },
+        { "command": "logmagnifier.disableAllItemsInGroup", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color00", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color01", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color02", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color03", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color04", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color05", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color06", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color07", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color08", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color09", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color10", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color11", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color12", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color13", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color14", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color15", "when": "false" },
+        { "command": "logmagnifier.changeFilterColor.color16", "when": "false" },
+        { "command": "logmagnifier.toggleFilterHighlightMode.word", "when": "false" },
+        { "command": "logmagnifier.toggleFilterHighlightMode.line", "when": "false" },
+        { "command": "logmagnifier.toggleFilterHighlightMode.full", "when": "false" },
+        { "command": "logmagnifier.toggleFilterCaseSensitivity.on", "when": "false" },
+        { "command": "logmagnifier.toggleFilterCaseSensitivity.off", "when": "false" },
+        { "command": "logmagnifier.toggleFilterType.include", "when": "false" },
+        { "command": "logmagnifier.toggleFilterType.exclude", "when": "false" },
+        { "command": "logmagnifier.toggleFilterContextLine_cl0", "when": "false" },
+        { "command": "logmagnifier.toggleFilterContextLine_cl3", "when": "false" },
+        { "command": "logmagnifier.toggleFilterContextLine_cl5", "when": "false" },
+        { "command": "logmagnifier.toggleFilterContextLine_cl9", "when": "false" },
+        { "command": "logmagnifier.togglePrependLineNumbers.enable", "when": "false" },
+        { "command": "logmagnifier.togglePrependLineNumbers.disable", "when": "false" },
+        { "command": "logmagnifier.setFilterType.include", "when": "false" },
+        { "command": "logmagnifier.setFilterType.exclude", "when": "false" },
+        { "command": "logmagnifier.setFilterCaseSensitivity.on", "when": "false" },
+        { "command": "logmagnifier.setFilterCaseSensitivity.off", "when": "false" },
+        { "command": "logmagnifier.setFilterHighlightMode.word", "when": "false" },
+        { "command": "logmagnifier.setFilterHighlightMode.line", "when": "false" },
+        { "command": "logmagnifier.setFilterHighlightMode.full", "when": "false" },
+        { "command": "logmagnifier.setFilterContextLine.none", "when": "false" },
+        { "command": "logmagnifier.setFilterContextLine.cl3", "when": "false" },
+        { "command": "logmagnifier.setFilterContextLine.cl5", "when": "false" },
+        { "command": "logmagnifier.setFilterContextLine.cl9", "when": "false" },
+        { "command": "logmagnifier.setExcludeStyle.lineThrough", "when": "false" },
+        { "command": "logmagnifier.setExcludeStyle.hidden", "when": "false" },
+        { "command": "logmagnifier.createFilter", "when": "false" },
+        { "command": "logmagnifier.createRegexFilter", "when": "false" },
+        { "command": "logmagnifier.deleteGroup", "when": "false" },
+        { "command": "logmagnifier.renameFilterGroup", "when": "false" },
+        { "command": "logmagnifier.editFilterItem", "when": "false" },
+        { "command": "logmagnifier.exportGroup", "when": "false" },
+        { "command": "logmagnifier.copyGroupEnabledItems", "when": "false" },
+        { "command": "logmagnifier.copyGroupEnabledItemsSingleLine", "when": "false" },
+        { "command": "logmagnifier.copyGroupEnabledItemsWithTag", "when": "false" },
+        { "command": "logmagnifier.expandAllWordGroups", "when": "false" },
+        { "command": "logmagnifier.collapseAllWordGroups", "when": "false" },
+        { "command": "logmagnifier.expandAllRegexGroups", "when": "false" },
+        { "command": "logmagnifier.collapseAllRegexGroups", "when": "false" },
+        { "command": "logmagnifier.jumpToBookmark", "when": "false" },
+        { "command": "logmagnifier.removeBookmark", "when": "false" },
+        { "command": "logmagnifier.refreshDevices", "when": "false" },
+        { "command": "logmagnifier.refreshRunbookView", "when": "false" },
+        { "command": "logmagnifier.pickTargetApp", "when": "false" },
+        { "command": "logmagnifier.pickAndLaunchInstalledApp", "when": "false" },
+        { "command": "logmagnifier.addLogcatSession", "when": "false" },
+        { "command": "logmagnifier.startLogcatSession", "when": "false" },
+        { "command": "logmagnifier.stopLogcatSession", "when": "false" },
+        { "command": "logmagnifier.removeLogcatSession", "when": "false" },
+        { "command": "logmagnifier.addLogcatTag", "when": "false" },
+        { "command": "logmagnifier.editLogcatTag", "when": "false" },
+        { "command": "logmagnifier.removeLogcatTag", "when": "false" },
+        { "command": "logmagnifier.session.enableTimeFilter", "when": "false" },
+        { "command": "logmagnifier.session.disableTimeFilter", "when": "false" },
+        { "command": "logmagnifier.control.uninstall", "when": "false" },
+        { "command": "logmagnifier.control.clearStorage", "when": "false" },
+        { "command": "logmagnifier.control.clearCache", "when": "false" },
+        { "command": "logmagnifier.control.toggleShowTouches", "when": "false" },
+        { "command": "logmagnifier.openChromeInspect", "when": "false" },
+        { "command": "logmagnifier.workflow.openResult", "when": "false" },
+        { "command": "logmagnifier.workflow.openAllResults", "when": "false" },
+        { "command": "logmagnifier.workflow.closeAllResults", "when": "false" },
+        { "command": "logmagnifier.workflow.edit", "when": "false" },
+        { "command": "logmagnifier.workflow.run", "when": "false" },
+        { "command": "logmagnifier.workflow.rename", "when": "false" },
+        { "command": "logmagnifier.runbook.editMarkdown", "when": "false" },
+        { "command": "logmagnifier.runbook.addGroup", "when": "false" },
+        { "command": "logmagnifier.runbook.addItem", "when": "false" },
+        { "command": "logmagnifier.runbook.deleteGroup", "when": "false" },
+        { "command": "logmagnifier.runbook.deleteItem", "when": "false" },
+        { "command": "logmagnifier.runbook.renameGroup", "when": "false" },
+        { "command": "logmagnifier.runbook.renameItem", "when": "false" },
+        { "command": "logmagnifier.toggleFileSizeUnit", "when": "false" }
+      ],
       "logmagnifier.editorContextSubmenu": [
         {
           "command": "logmagnifier.jumpToSource",


### PR DESCRIPTION
- Add "category": "LogMagnifier" to all user-facing commands for clear identification in the command palette (displays as "LogMagnifier: <title>")
- Hide 101 context-dependent commands from command palette via commandPalette menu entries with "when": "false"
- Hidden commands include: color pickers, filter property toggles, tree item operations, ADB controls, submenu items, and view-only buttons