### PR TITLE
ui: fix runbook group item indentation missing

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -312,6 +312,7 @@ export function activate(context: vscode.ExtensionContext) {
         try {
             wordTreeDataProvider.refresh();
             regexTreeDataProvider.refresh();
+            runbookTreeDataProvider.refresh();
         } catch (error) {
             logger.error(`Error in onDidChangeActiveColorTheme: ${error}`);
         }

--- a/src/test/views/RunbookTreeDataProvider.test.ts
+++ b/src/test/views/RunbookTreeDataProvider.test.ts
@@ -91,7 +91,7 @@ suite('RunbookTreeDataProvider Test Suite', () => {
             assert.strictEqual(treeItem.collapsibleState, vscode.TreeItemCollapsibleState.Collapsed);
             assert.strictEqual(treeItem.contextValue, 'runbookGroup');
             assert.strictEqual(treeItem.tooltip, '/path/group');
-            assert.strictEqual(treeItem.iconPath, vscode.ThemeIcon.Folder);
+            assert.ok(treeItem.iconPath instanceof vscode.Uri);
             assert.strictEqual(treeItem.description, '1 items');
         });
     });

--- a/src/views/RunbookTreeDataProvider.ts
+++ b/src/views/RunbookTreeDataProvider.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 import { RunbookService } from '../services/RunbookService';
 import { RunbookItem, RunbookMarkdown, RunbookGroup } from '../models/Runbook';
 import { Constants } from '../Constants';
+import { ThemeUtils } from '../utils/ThemeUtils';
+import { IconUtils } from '../utils/IconUtils';
 
 export class RunbookTreeDataProvider implements vscode.TreeDataProvider<RunbookItem>, vscode.Disposable {
     private _onDidChangeTreeData: vscode.EventEmitter<RunbookItem | undefined | null | void> = new vscode.EventEmitter<RunbookItem | undefined | null | void>();
@@ -57,7 +59,12 @@ export class RunbookTreeDataProvider implements vscode.TreeDataProvider<RunbookI
         const item = new vscode.TreeItem(group.label, vscode.TreeItemCollapsibleState.Collapsed);
         item.id = group.id;
         item.contextValue = 'runbookGroup';
-        item.iconPath = vscode.ThemeIcon.Folder;
+
+        const isDark = ThemeUtils.isDarkTheme();
+        const strokeColor = isDark ? '#cccccc' : '#333333';
+        const svg = IconUtils.generateGroupSvg(strokeColor);
+        item.iconPath = vscode.Uri.parse(`data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`);
+
         item.tooltip = group.dirPath;
         item.description = `${group.children.length} items`;
         return item;


### PR DESCRIPTION
Replace native folder ThemeIcons with custom SVG icons in the Runbook tree view. This prevents VS Code from applying compact file/folder heuristics that drop child indentations and ensures UI consistency with other tree views.