### PR TITLE
review: fix cross-review findings M3, M4, m1, m3

### DIFF
--- a/src/services/HighlightService.ts
+++ b/src/services/HighlightService.ts
@@ -328,7 +328,8 @@ export class HighlightService implements vscode.Disposable {
             let match;
 
             while ((match = regex.exec(text))) {
-                if (match[0].length === 0) {
+                const matchLength = match[0].length;
+                if (matchLength === 0) {
                     regex.lastIndex++;
                     continue;
                 }
@@ -346,7 +347,7 @@ export class HighlightService implements vscode.Disposable {
                     if (ctx.useLineRange) {
                         rangesByDeco.get(ctx.key)?.push(editor.document.lineAt(startPos.line).range);
                     } else {
-                        const endIndex = startIndex + match![0].length;
+                        const endIndex = startIndex + matchLength;
                         const absEndIndex = offset + endIndex;
                         const endPos = editor.document.positionAt(absEndIndex);
                         rangesByDeco.get(ctx.key)?.push(new vscode.Range(startPos, endPos));

--- a/src/services/LogBookmarkService.ts
+++ b/src/services/LogBookmarkService.ts
@@ -1,5 +1,4 @@
 import * as crypto from 'crypto';
-import * as fs from 'fs';
 
 import * as vscode from 'vscode';
 
@@ -142,14 +141,12 @@ export class LogBookmarkService implements vscode.Disposable {
         const checkPromises = keys.map(async (key) => {
             try {
                 const uri = vscode.Uri.parse(key);
-                if (uri.scheme === 'file') {
-                    try {
-                        await fs.promises.access(uri.fsPath);
-                        this.missingFiles.delete(key);
-                    } catch (_e: unknown) {
-                        // File not accessible — mark as missing
-                        this.missingFiles.add(key);
-                    }
+                try {
+                    await vscode.workspace.fs.stat(uri);
+                    this.missingFiles.delete(key);
+                } catch (_e: unknown) {
+                    // File not accessible — mark as missing
+                    this.missingFiles.add(key);
                 }
             } catch (e: unknown) {
                 const msg = e instanceof Error ? e.message : String(e);

--- a/src/services/adb/AdbTargetAppService.ts
+++ b/src/services/adb/AdbTargetAppService.ts
@@ -7,6 +7,7 @@ import { AdbClient } from './AdbClient';
 
 export class AdbTargetAppService {
     private static readonly scanConcurrency = 8;
+    private static readonly packageNamePattern = /^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$/;
     private deviceTargetApps: Map<string, string> = new Map(); // deviceId -> packageName
     private launchableAppsCache: Map<string, { packageName: string, componentName: string }[]> = new Map();
     private launchableAppScanPromises: Map<string, Promise<void>> = new Map();
@@ -18,6 +19,10 @@ export class AdbTargetAppService {
 
     /** Sets the target app for logcat filtering on the given device. */
     public setTargetApp(device: AdbDevice, packageName: string) {
+        if (!AdbTargetAppService.packageNamePattern.test(packageName)) {
+            this.logger.warn(`[AdbTargetAppService] Invalid package name rejected: ${packageName}`);
+            return;
+        }
         this.deviceTargetApps.set(device.id, packageName);
         device.targetApp = packageName;
         this._onDidChangeTargetApp.fire();

--- a/src/views/FilterTreeDataProvider.ts
+++ b/src/views/FilterTreeDataProvider.ts
@@ -251,6 +251,7 @@ export class FilterTreeDataProvider implements vscode.TreeDataProvider<TreeItem>
     /** Clears the icon cache and disposes all subscriptions. */
     public dispose() {
         this.iconCache.clear();
+        this._onDidChangeTreeData.dispose();
         this.disposables.forEach(d => d.dispose());
         this.disposables = [];
     }


### PR DESCRIPTION
## Summary
- **M3**: Dispose `_onDidChangeTreeData` EventEmitter in `FilterTreeDataProvider.dispose()`
- **M4**: Remove `match![0].length` non-null assertion in `HighlightService` by caching to local variable
- **m1**: Use `vscode.workspace.fs.stat()` instead of `fs.promises.access()` in `LogBookmarkService` for remote environment support
- **m3**: Add Android package name format validation in `AdbTargetAppService.setTargetApp()`

## Test plan
- [x] `rm -rf out/ dist/ && npm test` — 600 tests passing
- [ ] Verify filter tree view dispose works without EventEmitter leak
- [ ] Verify highlight decorations render correctly with regex matches
- [ ] Verify bookmark file existence check works in remote workspace
- [ ] Verify invalid package names are rejected in ADB target app selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)