### PR TITLE
readme: migrate badge URLs to vsmarketplacebadges.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LogMagnifier
 
-[![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/webispy.logmagnifier)](https://marketplace.visualstudio.com/items?itemName=webispy.logmagnifier)
-[![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/webispy.logmagnifier)](https://marketplace.visualstudio.com/items?itemName=webispy.logmagnifier)
+[![Visual Studio Marketplace Version](https://vsmarketplacebadges.dev/version-short/webispy.logmagnifier.svg)](https://marketplace.visualstudio.com/items?itemName=webispy.logmagnifier)
+[![Visual Studio Marketplace Installs](https://vsmarketplacebadges.dev/installs/webispy.logmagnifier.svg)](https://marketplace.visualstudio.com/items?itemName=webispy.logmagnifier)
 [![Build Status](https://github.com/webispy/vscode-logmagnifier/actions/workflows/package.yml/badge.svg)](https://github.com/webispy/vscode-logmagnifier/actions/workflows/package.yml)
 [![codecov](https://codecov.io/gh/webispy/vscode-logmagnifier/branch/main/graph/badge.svg)](https://app.codecov.io/github/webispy/vscode-logmagnifier)
 


### PR DESCRIPTION
## Summary
- shields.io에서 Visual Studio Marketplace badge 지원을 중단하여 badge 이미지 URL을 `vsmarketplacebadges.dev`로 변경
- Version, Installs 두 badge 대상

## Test plan
- [ ] README.md에서 badge 이미지가 정상 렌더링되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)