### PR TITLE
review: fix v3 findings M1-M5, m1-m8

### DIFF
--- a/src/commands/CommandManager.ts
+++ b/src/commands/CommandManager.ts
@@ -68,7 +68,7 @@ export class CommandManager {
         new FilterGroupCommandManager(context, this.filterManager, this.logger);
         new FilterItemCommandManager(context, this.filterManager, this.logger, this.textTreeView);
         new FilterPropertyCommandManager(context, this.filterManager);
-        new FilterExportImportCommandManager(context, this.filterManager);
+        new FilterExportImportCommandManager(context, this.filterManager, this.logger);
         new FilterExecutionCommandManager(context, this.filterManager, this.highlightService, this.logProcessor, this.logger, this.lineMappingService, this.textTreeView, this.regexTreeView);
         new EditorToggleCommandManager(context, this.dashboardProvider, this.jsonPrettyService);
 

--- a/src/commands/FilterExportImportCommandManager.ts
+++ b/src/commands/FilterExportImportCommandManager.ts
@@ -9,6 +9,7 @@ import { Constants } from '../Constants';
 import { FilterGroup } from '../models/Filter';
 
 import { FilterManager } from '../services/FilterManager';
+import { Logger } from '../services/Logger';
 import { IconUtils } from '../utils/IconUtils';
 import { ThemeUtils } from '../utils/ThemeUtils';
 
@@ -20,7 +21,8 @@ interface FilterGroupQuickPickItem extends vscode.QuickPickItem {
 export class FilterExportImportCommandManager {
     constructor(
         private readonly context: vscode.ExtensionContext,
-        private readonly filterManager: FilterManager
+        private readonly filterManager: FilterManager,
+        private readonly logger: Logger
     ) {
         this.registerCommands();
     }
@@ -157,6 +159,7 @@ export class FilterExportImportCommandManager {
                 await fsp.writeFile(uri.fsPath, filtersJson, 'utf8');
                 vscode.window.showInformationMessage(Constants.Messages.Info.ExportSuccess.replace('{0}', mode === 'text' ? 'Text' : 'Regex').replace('{1}', uri.fsPath));
             } catch (e: unknown) {
+                this.logger.error(`[FilterExportImport] Export failed: ${e instanceof Error ? e.message : String(e)}`);
                 vscode.window.showErrorMessage(Constants.Messages.Error.ExportFailed.replace('{0}', e instanceof Error ? e.message : String(e)));
             }
         }
@@ -196,6 +199,7 @@ export class FilterExportImportCommandManager {
                 await fsp.writeFile(uri.fsPath, filtersJson, 'utf8');
                 vscode.window.showInformationMessage(Constants.Messages.Info.ExportGroupSuccess.replace('{0}', group.name).replace('{1}', uri.fsPath));
             } catch (e: unknown) {
+                this.logger.error(`[FilterExportImport] Export group failed: ${e instanceof Error ? e.message : String(e)}`);
                 vscode.window.showErrorMessage(Constants.Messages.Error.ExportGroupFailed.replace('{0}', e instanceof Error ? e.message : String(e)));
             }
         }
@@ -240,6 +244,7 @@ export class FilterExportImportCommandManager {
                     vscode.window.showInformationMessage(Constants.Messages.Info.ImportSuccess.replace('{0}', result.count.toString()).replace('{1}', mode === 'text' ? 'Text' : 'Regex'));
                 }
             } catch (e: unknown) {
+                this.logger.error(`[FilterExportImport] Import failed: ${e instanceof Error ? e.message : String(e)}`);
                 vscode.window.showErrorMessage(Constants.Messages.Error.ReadFilterFileFailed.replace('{0}', e instanceof Error ? e.message : String(e)));
             }
         }
@@ -311,7 +316,9 @@ export class FilterExportImportCommandManager {
 
                     // Refresh list
                     quickPick.hide();
-                    vscode.commands.executeCommand(Constants.Commands.ManageProfiles).then(undefined, () => { /* command routing error is non-fatal */ });
+                    vscode.commands.executeCommand(Constants.Commands.ManageProfiles).then(undefined, (e: unknown) => {
+                        this.logger.warn(`[FilterExportImport] Command routing error: ${e instanceof Error ? e.message : String(e)}`);
+                    });
                 }
             });
 

--- a/src/commands/NavigationCommandManager.ts
+++ b/src/commands/NavigationCommandManager.ts
@@ -139,7 +139,7 @@ export class NavigationCommandManager {
             if (selection && selection.detail) {
                 let targetUri: vscode.Uri | undefined;
 
-                if (selection.detail.startsWith('Untitled:') || selection.detail.startsWith('untitled:')) {
+                if (selection.detail.startsWith('untitled:')) {
                     targetUri = vscode.Uri.parse(selection.detail);
                 } else {
                     targetUri = vscode.Uri.file(selection.detail);

--- a/src/services/FilterManager.ts
+++ b/src/services/FilterManager.ts
@@ -28,6 +28,7 @@ export class FilterManager implements vscode.Disposable {
     private profileManager: ProfileManager;
     private stateService: FilterStateService;
     private configDisposable: vscode.Disposable;
+    private profileDisposable: vscode.Disposable;
     private saveDebounceTimer: NodeJS.Timeout | undefined;
 
     constructor(private readonly context: vscode.ExtensionContext) {
@@ -41,7 +42,7 @@ export class FilterManager implements vscode.Disposable {
         this.initDefaultFilters();
 
         // Relay profile changes & Reload filters
-        this.profileManager.onDidChangeProfile(async () => {
+        this.profileDisposable = this.profileManager.onDidChangeProfile(async () => {
             this._onDidChangeProfile.fire();
             await this.reloadFromProfile();
         });
@@ -994,5 +995,6 @@ export class FilterManager implements vscode.Disposable {
         this._onDidChangeResultCounts.dispose();
         this._onDidChangeProfile.dispose();
         this.configDisposable.dispose();
+        this.profileDisposable.dispose();
     }
 }

--- a/src/services/FilterStateService.ts
+++ b/src/services/FilterStateService.ts
@@ -142,7 +142,8 @@ export class FilterStateService {
             delete legacy['contextLine'];
         }
 
-        // Migrate legacy 'line-through' excludeStyle to 'strikethrough'
+        // Migrate legacy 'line-through' excludeStyle to 'strikethrough' (pre-v1.6 data)
+        // Safe to remove once all users have migrated past v1.6
         if (filter.excludeStyle === 'line-through' as string) {
             filter.excludeStyle = 'strikethrough';
         }

--- a/src/services/LineMappingService.ts
+++ b/src/services/LineMappingService.ts
@@ -55,10 +55,15 @@ export class LineMappingService {
      * @param line Line number in the filtered file (0-based)
      */
     public getOriginalLocation(filteredUri: vscode.Uri, line: number): vscode.Location | undefined {
-        const mapping = this.mappings.get(filteredUri.toString());
+        const key = filteredUri.toString();
+        const mapping = this.mappings.get(key);
         if (!mapping) {
             return undefined;
         }
+
+        // LRU: Refresh by deleting and re-inserting
+        this.mappings.delete(key);
+        this.mappings.set(key, mapping);
 
         const originalLine = mapping.lineMapping[line];
         if (originalLine === undefined) {

--- a/src/services/LogBookmarkService.ts
+++ b/src/services/LogBookmarkService.ts
@@ -589,12 +589,12 @@ export class LogBookmarkService implements vscode.Disposable {
                         }
 
                         return {
-                            id: b.id as string,
-                            uri: vscode.Uri.parse(b.uri as string),
+                            id: typeof b.id === 'string' ? b.id : String(b.id),
+                            uri: vscode.Uri.parse(typeof b.uri === 'string' ? b.uri : String(b.uri)),
                             line: typeof b.line === 'number' ? b.line : 0,
-                            content: (b.content as string) || '',
-                            groupId: (b.groupId as string) || Date.now().toString(), // Fallback for old bookmarks
-                            matchText: b.matchText as string | undefined
+                            content: typeof b.content === 'string' ? b.content : '',
+                            groupId: typeof b.groupId === 'string' ? b.groupId : Date.now().toString(),
+                            matchText: typeof b.matchText === 'string' ? b.matchText : undefined
                         } as BookmarkItem;
                     } catch (e: unknown) {
                         const msg = e instanceof Error ? e.message : String(e);

--- a/src/test/views/LogBookmarkWebviewProvider.test.ts
+++ b/src/test/views/LogBookmarkWebviewProvider.test.ts
@@ -42,6 +42,7 @@ suite('LogBookmarkWebviewProvider Test Suite', () => {
                 options: {},
                 onDidReceiveMessage: (_listener: unknown) => {
                     listenerRegistered = true;
+                    return { dispose: () => { } };
                 },
                 html: ''
             }

--- a/src/tools/ExtractJsonTool.ts
+++ b/src/tools/ExtractJsonTool.ts
@@ -94,7 +94,7 @@ export class ExtractJsonTool implements vscode.LanguageModelTool<ExtractJsonInpu
                     try {
                         const parsed = JSON.parse(bounded.text);
                         found.push({ text: bounded.text, parsed });
-                    } catch {
+                    } catch (_e: unknown) {
                         found.push({ text: bounded.text });
                     }
                 }

--- a/src/tools/ExtractLogsWithMarginTool.ts
+++ b/src/tools/ExtractLogsWithMarginTool.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -91,7 +91,7 @@ export class ExtractLogsWithMarginTool implements vscode.LanguageModelTool<Extra
 
         try {
             const tmpFile = path.join(os.tmpdir(), `LM_margin_${Date.now()}.log`);
-            fs.writeFileSync(tmpFile, result.filteredLines.join('\n'), 'utf-8');
+            await fsp.writeFile(tmpFile, result.filteredLines.join('\n'), 'utf-8');
 
             const outputUri = vscode.Uri.file(tmpFile);
             this.lineMappingService.register(outputUri, doc.uri, result.lineMapping);

--- a/src/tools/FilterByTimeRangeTool.ts
+++ b/src/tools/FilterByTimeRangeTool.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -94,7 +94,7 @@ export class FilterByTimeRangeTool implements vscode.LanguageModelTool<FilterByT
         try {
             // Write filtered output to temp file
             const tmpFile = path.join(os.tmpdir(), `LM_timerange_${Date.now()}.log`);
-            fs.writeFileSync(tmpFile, result.filteredLines.join('\n'), 'utf-8');
+            await fsp.writeFile(tmpFile, result.filteredLines.join('\n'), 'utf-8');
 
             // Register line mapping
             const outputUri = vscode.Uri.file(tmpFile);

--- a/src/tools/SearchLogTool.ts
+++ b/src/tools/SearchLogTool.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { Logger } from '../services/Logger';
+import { RegexUtils } from '../utils/RegexUtils';
 
 interface SearchLogInput {
     pattern: string;
@@ -29,15 +30,7 @@ export class SearchLogTool implements vscode.LanguageModelTool<SearchLogInput> {
         const maxResults = options.input.maxResults ?? 50;
         const ctx = contextLines ?? 0;
 
-        let regex: RegExp;
-        try {
-            const flags = caseSensitive ? 'g' : 'gi';
-            regex = isRegex ? new RegExp(pattern, flags) : new RegExp(this.escapeRegex(pattern), flags);
-        } catch (e: unknown) {
-            return new vscode.LanguageModelToolResult([
-                new vscode.LanguageModelTextPart(`Invalid pattern: ${e instanceof Error ? e.message : String(e)}`)
-            ]);
-        }
+        const regex = RegexUtils.create(pattern, isRegex ?? false, caseSensitive ?? false);
 
         const doc = editor.document;
         const matches: { line: number; text: string; context?: string[] }[] = [];
@@ -92,9 +85,5 @@ export class SearchLogTool implements vscode.LanguageModelTool<SearchLogInput> {
         return new vscode.LanguageModelToolResult([
             new vscode.LanguageModelTextPart(JSON.stringify(result, null, 2))
         ]);
-    }
-
-    private escapeRegex(str: string): string {
-        return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     }
 }

--- a/src/utils/EditorUtils.ts
+++ b/src/utils/EditorUtils.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as fsp from 'fs/promises';
 
 import * as vscode from 'vscode';
 
@@ -64,8 +64,11 @@ export class EditorUtils {
                     return stat.size;
                 } catch (_e: unknown) {
                     // Fallback to node fs if workspace fs fails (though workspace.fs is preferred)
-                    if (fs.existsSync(uri.fsPath)) {
-                        return fs.statSync(uri.fsPath).size;
+                    try {
+                        const stat = await fsp.stat(uri.fsPath);
+                        return stat.size;
+                    } catch (_fallback: unknown) {
+                        // File does not exist or is inaccessible
                     }
                 }
             }

--- a/src/views/AdbDeviceTreeProvider.ts
+++ b/src/views/AdbDeviceTreeProvider.ts
@@ -325,7 +325,7 @@ export class AdbDeviceTreeProvider implements vscode.TreeDataProvider<AdbTreeIte
                 try {
                     showTouchesState = await this.adbService.getShowTouchesState(element.device.id);
                 } catch (_e: unknown) {
-                    // Fall back to false on error
+                    // Non-critical: fall back to false if showTouches state cannot be read
                 }
                 return [
                     { type: 'controlDeviceAction', actionType: 'screenshot', device: element.device } as ControlDeviceActionItem,

--- a/src/views/DashboardProvider.ts
+++ b/src/views/DashboardProvider.ts
@@ -8,7 +8,7 @@ import { WorkflowManager } from '../services/WorkflowManager';
 import { EditorUtils } from '../utils/EditorUtils';
 
 export class DashboardProvider implements vscode.TreeDataProvider<vscode.TreeItem>, vscode.Disposable {
-    private _onDidChangeTreeData: vscode.EventEmitter<vscode.TreeItem | undefined | null | void> = new vscode.EventEmitter<vscode.TreeItem | undefined | null | void>();
+    private readonly _onDidChangeTreeData: vscode.EventEmitter<vscode.TreeItem | undefined | null | void> = new vscode.EventEmitter<vscode.TreeItem | undefined | null | void>();
     readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | undefined | null | void> = this._onDidChangeTreeData.event;
     private disposables: vscode.Disposable[] = [];
     private fileSizeUnit: 'bytes' | 'kb' | 'mb' = 'bytes';

--- a/src/views/FilterTreeDataProvider.ts
+++ b/src/views/FilterTreeDataProvider.ts
@@ -12,7 +12,7 @@ type TreeItem = FilterGroup | FilterItem;
 export class FilterTreeDataProvider implements vscode.TreeDataProvider<TreeItem>, vscode.TreeDragAndDropController<TreeItem>, vscode.Disposable {
     private static readonly maxIconCacheSize = 200;
 
-    private _onDidChangeTreeData: vscode.EventEmitter<TreeItem | undefined | void> = new vscode.EventEmitter<TreeItem | undefined | void>();
+    private readonly _onDidChangeTreeData: vscode.EventEmitter<TreeItem | undefined | void> = new vscode.EventEmitter<TreeItem | undefined | void>();
     readonly onDidChangeTreeData: vscode.Event<TreeItem | undefined | void> = this._onDidChangeTreeData.event;
 
     dropMimeTypes = ['application/vnd.code.tree.logmagnifier-filters'];

--- a/src/views/LogBookmarkWebviewProvider.ts
+++ b/src/views/LogBookmarkWebviewProvider.ts
@@ -105,7 +105,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider, v
                 ]
             };
 
-            webviewView.webview.onDidReceiveMessage((data: BookmarkWebviewMessage) => {
+            this.disposables.push(webviewView.webview.onDidReceiveMessage((data: BookmarkWebviewMessage) => {
                 switch (data.type) {
                     case 'jump':
                         if (data.item) {
@@ -182,7 +182,7 @@ export class LogBookmarkWebviewProvider implements vscode.WebviewViewProvider, v
                         }
                         break;
                 }
-            });
+            }));
 
             this.updateContent().catch((e: unknown) =>
                 this.logger.error(`[BookmarkWebview] Update failed: ${e instanceof Error ? e.message : String(e)}`)

--- a/src/views/WorkflowWebviewProvider.ts
+++ b/src/views/WorkflowWebviewProvider.ts
@@ -66,11 +66,10 @@ export class WorkflowWebviewProvider implements vscode.WebviewViewProvider, vsco
             }, null, this.disposables);
 
             // Cleanup when view is disposed
-            const disposeSubscription = webviewView.onDidDispose(() => {
+            webviewView.onDidDispose(() => {
                 this.disposables.forEach(d => d.dispose());
                 this.disposables = [];
-                disposeSubscription.dispose();
-            });
+            }, null, this.disposables);
 
         } catch (e: unknown) {
             this.logger.error(`[WorkflowWebviewProvider] Error resolving webview: ${e instanceof Error ? e.message : String(e)}`);


### PR DESCRIPTION
## Summary

- **Major (M1-M5)**: ReDoS 방어(SearchLogTool→RegexUtils), 리소스 누수 수정(FilterManager/LogBookmarkWebviewProvider/WorkflowWebviewProvider 구독 추적), LineMappingService FIFO→LRU 전환
- **Minor (m1-m8)**: Logger 주입, bare catch 수정, 동기→async I/O, 데드 코드 제거, 런타임 타입 검증, EventEmitter readonly 추가
- 18개 파일 변경, 609 tests passing

## Test plan

- [x] `rm -rf out/ dist/ && npm test` 전체 빌드 + 테스트 통과 (609 passing)
- [ ] SearchLogTool에서 악의적 regex 패턴 입력 시 ReDoS 방어 확인
- [ ] FilterManager dispose 후 프로필 변경 이벤트 누수 없음 확인
- [ ] LineMappingService에서 자주 접근하는 매핑이 LRU 정책으로 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)