### PR TITLE
filter: fix wrong file targeted in split editor with large files

### DIFF
--- a/src/commands/FilterExecutionCommandManager.ts
+++ b/src/commands/FilterExecutionCommandManager.ts
@@ -93,6 +93,7 @@ export class FilterExecutionCommandManager {
                 if (uri) {
                     if (uri.scheme === 'file') {
                         filePathFromTab = uri.fsPath;
+                        this.logger.info(`[FilterExecution] Resolved target via Tab URI (large file): ${filePathFromTab}`);
                     } else if (uri.scheme === 'untitled') {
                         try {
                             // Try to open validation doc if possible
@@ -109,6 +110,10 @@ export class FilterExecutionCommandManager {
                 vscode.window.showErrorMessage(Constants.Messages.Error.NoActiveFile);
                 return;
             }
+
+            // Log the actual target for debugging split-editor scenarios
+            const resolvedTarget = filePathFromTab || document?.uri.fsPath || 'unknown';
+            this.logger.info(`[FilterExecution] Apply filter target: ${resolvedTarget} (source: ${filePathFromTab ? 'Tab URI' : 'TextDocument'})`);
 
             let outputPath = '';
             const stats = { processed: 0, matched: 0 };

--- a/src/utils/EditorUtils.ts
+++ b/src/utils/EditorUtils.ts
@@ -107,12 +107,17 @@ export class EditorUtils {
                         document = await vscode.workspace.openTextDocument(uri);
                     } catch (e: unknown) {
                         Logger.getInstance().error(`[EditorUtils] Failed to resolve document from tab: ${e instanceof Error ? e.message : String(e)}`);
+                        // Active tab is identified but document cannot be opened (e.g. large file).
+                        // Return undefined instead of falling back to visible editors,
+                        // which would incorrectly pick a file from another split pane.
+                        // The caller can use resolveActiveUri() to get the file path directly.
+                        return undefined;
                     }
                 }
             }
         }
 
-        // Last resort: check visible editors
+        // Last resort: check visible editors (only when no active tab was identified)
         if (!document) {
             const visible = vscode.window.visibleTextEditors;
             const supportedEditor = visible.find(e => e.document.uri.scheme === Constants.Schemes.File || e.document.uri.scheme === Constants.Schemes.Untitled);


### PR DESCRIPTION
## Summary

- Split editor에서 active tab이 대용량 파일(>50MB)일 때 apply filter가 반대편 split의 엉뚱한 파일에 적용되는 버그 수정
- `resolveActiveDocument()`에서 active tab의 문서를 열 수 없을 때 visible editors fallback으로 넘기지 않고 즉시 undefined 반환하도록 변경
- apply filter 대상 파일을 로그에 출력하는 진단 로깅 추가

### Root cause

`visibleTextEditors`는 "열린 탭"이 아니라 화면에 실제로 렌더링된 TextEditor 인스턴스만 포함합니다. Split 없이는 대용량 파일의 TextEditor가 없어 배열이 비어 있지만, split 상태에서는 반대편 pane의 에디터가 visible하므로 fallback이 그 파일을 잘못 선택했습니다.

## Test plan

- [x] Split editor에서 대용량 파일 active tab 상태로 apply filter 실행 → 해당 파일에 필터 적용 확인
- [x] Split 없는 상태에서 대용량 파일 apply filter 정상 동작 확인
- [x] 일반 파일(< 50MB) apply filter 기존 동작 유지 확인
- [x] `npm test` 전체 통과 (609 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)