### PR TITLE
ux: add viewsWelcome for empty tree views (U2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1141,7 +1141,24 @@
         ]
       }
     ],
-    "viewsWelcome": [],
+    "viewsWelcome": [
+      {
+        "view": "logmagnifier-text-filters",
+        "contents": "No text filters yet.\n[Add Group](command:logmagnifier.addTextFilterGroup)\n[Import Filters](command:logmagnifier.importTextFilters)"
+      },
+      {
+        "view": "logmagnifier-regex-filters",
+        "contents": "No regex filters yet.\n[Add Group](command:logmagnifier.addRegexFilterGroup)\n[Import Filters](command:logmagnifier.importRegexFilters)"
+      },
+      {
+        "view": "logmagnifier-runbook",
+        "contents": "No runbook entries yet.\n[Add Group](command:logmagnifier.runbook.addGroup)\n[Import Runbook](command:logmagnifier.runbook.import)"
+      },
+      {
+        "view": "logmagnifier-time-range",
+        "contents": "Open a log file with timestamp entries to explore time ranges here."
+      }
+    ],
     "keybindings": [
       {
         "command": "logmagnifier.nextMatch",

--- a/resources/webview/workflow-tree-template.html
+++ b/resources/webview/workflow-tree-template.html
@@ -357,7 +357,18 @@
                 container.innerHTML = '';
 
                 if (!workflows || workflows.length === 0) {
-                    container.innerHTML = '<div style="padding: 20px; text-align: center; color: var(--vscode-descriptionForeground);">No workflows created.<br>Click "+" in the menu or use Command Palette to create one.</div>';
+                    container.innerHTML = `
+                        <div style="padding: 20px 24px; color: var(--vscode-foreground); font-size: 13px; line-height: 1.6;">
+                            <p style="margin: 0 0 12px;">No workflows yet.</p>
+                            <p style="margin: 0 0 6px;">
+                                <a href="#" onclick="post('create',{}); return false;"
+                                   style="color: var(--vscode-textLink-foreground); text-decoration: none;">New Workflow</a>
+                            </p>
+                            <p style="margin: 0;">
+                                <a href="#" onclick="post('import',{}); return false;"
+                                   style="color: var(--vscode-textLink-foreground); text-decoration: none;">Import Workflow</a>
+                            </p>
+                        </div>`;
                     return;
                 }
 

--- a/src/test/views/WorkflowWebviewProvider.test.ts
+++ b/src/test/views/WorkflowWebviewProvider.test.ts
@@ -66,11 +66,14 @@ suite('WorkflowWebviewProvider Test Suite', () => {
 
     test('refresh posts update message', async () => {
         let postedMessage: { type?: string } | undefined;
+        let htmlValue = '';
+
         const mockWebviewView = {
             webview: {
                 options: {},
                 onDidReceiveMessage: () => { },
-                html: '',
+                get html() { return htmlValue; },
+                set html(v: string) { htmlValue = v; },
                 postMessage: async (msg: unknown) => {
                     postedMessage = msg as { type?: string };
                 }
@@ -87,7 +90,7 @@ suite('WorkflowWebviewProvider Test Suite', () => {
 
         await provider.refresh();
 
-        assert.ok(postedMessage);
+        assert.ok(postedMessage, 'postMessage should be called on refresh');
         assert.strictEqual(postedMessage.type, 'update');
     });
 });

--- a/src/views/WorkflowWebviewProvider.ts
+++ b/src/views/WorkflowWebviewProvider.ts
@@ -13,6 +13,7 @@ export class WorkflowWebviewProvider implements vscode.WebviewViewProvider, vsco
     private view?: vscode.WebviewView;
     private disposables: vscode.Disposable[] = [];
     private readonly htmlGenerator: WorkflowHtmlGenerator;
+    private viewInitialized = false;
 
     constructor(
         private readonly context: vscode.ExtensionContext,
@@ -38,11 +39,7 @@ export class WorkflowWebviewProvider implements vscode.WebviewViewProvider, vsco
                 ]
             };
 
-            const workflows = await this.workflowManager.getWorkflowViewModels();
-            const activeId = this.workflowManager.getActiveWorkflow();
-            const activeStepId = this.workflowManager.getActiveStep();
-
-            webviewView.webview.html = await this.htmlGenerator.generate(webviewView.webview, workflows, activeId, activeStepId);
+            await this.updateView();
 
             webviewView.webview.onDidReceiveMessage(
                 (data) => this.handleMessage(data),
@@ -69,6 +66,8 @@ export class WorkflowWebviewProvider implements vscode.WebviewViewProvider, vsco
             webviewView.onDidDispose(() => {
                 this.disposables.forEach(d => d.dispose());
                 this.disposables = [];
+                this.view = undefined;
+                this.viewInitialized = false;
             }, null, this.disposables);
 
         } catch (e: unknown) {
@@ -77,17 +76,27 @@ export class WorkflowWebviewProvider implements vscode.WebviewViewProvider, vsco
         }
     }
 
-    /** Sends updated workflow data to the webview via postMessage. */
+    /** Sends updated workflow data to the webview via postMessage, or generates full HTML on first render. */
     public async refresh() {
-        if (this.view) {
-            const workflows = await this.workflowManager.getWorkflowViewModels();
-            const activeId = this.workflowManager.getActiveWorkflow();
+        await this.updateView();
+    }
 
+    private async updateView(): Promise<void> {
+        if (!this.view) { return; }
+
+        const workflows = await this.workflowManager.getWorkflowViewModels();
+        const activeId = this.workflowManager.getActiveWorkflow();
+        const activeStepId = this.workflowManager.getActiveStep();
+
+        if (!this.viewInitialized) {
+            this.view.webview.html = await this.htmlGenerator.generate(this.view.webview, workflows, activeId, activeStepId);
+            this.viewInitialized = true;
+        } else {
             this.view.webview.postMessage({
                 type: 'update',
-                workflows: workflows,
-                activeId: activeId,
-                activeStepId: this.workflowManager.getActiveStep()
+                workflows,
+                activeId,
+                activeStepId
             });
         }
     }


### PR DESCRIPTION
## Summary

- `contributes.viewsWelcome` 항목을 Text Filters, Regex Filters, Runbook, Time Range 뷰에 추가하여 빈 상태에서 CTA 링크 표시
- Dashboard, ADB Devices(항상 트리 아이템 존재), Bookmark(WebviewView) 는 제외
- Workflow 웹뷰의 빈 상태 UI를 VS Code CSS 변수(`--vscode-textLink-foreground`) 기반 링크로 개선 (New Workflow / Import Workflow)
- `WorkflowWebviewProvider`에 `viewInitialized` 플래그 추가: 최초 렌더링은 full HTML 생성, 이후 변경은 `postMessage`로 처리; dispose 시 플래그 초기화

## Test plan

- [ ] Text Filters 뷰가 비었을 때 "No text filters yet." + Add Group / Import Filters CTA 표시 확인
- [ ] Regex Filters 뷰가 비었을 때 동일하게 CTA 표시 확인
- [ ] Runbook 뷰가 비었을 때 CTA 표시 확인
- [ ] Time Range 뷰가 비었을 때 안내 문구 표시 확인
- [ ] Workflow 뷰가 비었을 때 링크 스타일 빈 상태 UI 표시 확인
- [ ] Workflow에서 New Workflow / Import Workflow 링크 클릭 시 해당 동작 실행 확인
- [ ] `npm test` 609 passing

Closes #263 (U2)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)