### PR TITLE
ux: split keybindings to mac/win/linux (U5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ coverage
 .claude/settings.local.json
 .agent/plans/
 .agent/designs/
+.agent/ideas/
 reports/

--- a/package.json
+++ b/package.json
@@ -1145,37 +1145,44 @@
     "keybindings": [
       {
         "command": "logmagnifier.nextMatch",
-        "key": "ctrl+cmd+]",
+        "key": "ctrl+alt+]",
+        "mac": "ctrl+cmd+]",
         "when": "editorTextFocus || focusedView == logmagnifier-text-filters || focusedView == logmagnifier-regex-filters"
       },
       {
         "command": "logmagnifier.previousMatch",
-        "key": "ctrl+cmd+[",
+        "key": "ctrl+alt+[",
+        "mac": "ctrl+cmd+[",
         "when": "editorTextFocus || focusedView == logmagnifier-text-filters || focusedView == logmagnifier-regex-filters"
       },
       {
         "command": "logmagnifier.removeMatchesWithSelection",
-        "key": "ctrl+cmd+r",
+        "key": "ctrl+alt+r",
+        "mac": "ctrl+cmd+r",
         "when": "editorTextFocus && editorHasSelection"
       },
       {
         "command": "logmagnifier.applyJsonPretty",
-        "key": "ctrl+cmd+j",
+        "key": "ctrl+alt+j",
+        "mac": "ctrl+cmd+j",
         "when": "editorTextFocus"
       },
       {
         "command": "logmagnifier.toggleBookmark",
-        "key": "ctrl+cmd+b",
+        "key": "ctrl+alt+b",
+        "mac": "ctrl+cmd+b",
         "when": "editorTextFocus"
       },
       {
         "command": "logmagnifier.toggleWordWrap",
-        "key": "ctrl+cmd+w",
+        "key": "ctrl+alt+w",
+        "mac": "ctrl+cmd+w",
         "when": "editorTextFocus && !logmagnifier.bookmark.mouseOver && focusedView != logmagnifier-bookmark"
       },
       {
         "command": "logmagnifier.bookmark.toggleWordWrap",
-        "key": "ctrl+cmd+w",
+        "key": "ctrl+alt+w",
+        "mac": "ctrl+cmd+w",
         "when": "logmagnifier.bookmark.mouseOver || focusedView == logmagnifier-bookmark"
       },
       {
@@ -1185,12 +1192,13 @@
       },
       {
         "command": "logmagnifier.hierarchy.showFullTree",
-        "key": "ctrl+cmd+t",
+        "key": "ctrl+alt+t",
+        "mac": "ctrl+cmd+t",
         "when": "editorTextFocus"
       },
       {
         "command": "logmagnifier.timestamp.gotoTime",
-        "key": "ctrl+cmd+g",
+        "key": "ctrl+alt+g",
         "mac": "ctrl+cmd+g",
         "when": "editorTextFocus"
       }


### PR DESCRIPTION
## Summary

- 기존 10개 keybinding이 모두 `ctrl+cmd+*` (Mac 전용)으로 Windows/Linux에서 동작하지 않는 문제 수정
- 각 바인딩을 `mac: ctrl+cmd+*` + `key: ctrl+alt+*` 형태로 분리하여 크로스플랫폼 지원
- `space` 바인딩(ADB Devices Chrome Inspect)은 플랫폼 중립이므로 변경 없음
- `.agent/ideas/` 디렉토리를 `.gitignore`에 추가

## 변경된 keybinding 매핑

| Command | Mac | Win/Linux |
|---|---|---|
| nextMatch | ctrl+cmd+] | ctrl+alt+] |
| previousMatch | ctrl+cmd+[ | ctrl+alt+[ |
| removeMatchesWithSelection | ctrl+cmd+r | ctrl+alt+r |
| applyJsonPretty | ctrl+cmd+j | ctrl+alt+j |
| toggleBookmark | ctrl+cmd+b | ctrl+alt+b |
| toggleWordWrap | ctrl+cmd+w | ctrl+alt+w |
| bookmark.toggleWordWrap | ctrl+cmd+w | ctrl+alt+w |
| hierarchy.showFullTree | ctrl+cmd+t | ctrl+alt+t |
| timestamp.gotoTime | ctrl+cmd+g | ctrl+alt+g |

## Test plan

- [ ] Mac에서 기존 ctrl+cmd+* 단축키 정상 동작 확인
- [ ] Windows/Linux에서 ctrl+alt+* 단축키 동작 확인
- [ ] `npm test` 609 passing

Closes #263 (U5)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)