### PR TITLE
ux: add unified export entry point (U11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1553,6 +1553,12 @@
         "icon": "$(json)"
       },
       {
+        "command": "logmagnifier.export",
+        "title": "Export Filters...",
+        "category": "LogMagnifier",
+        "icon": "$(repo-push)"
+      },
+      {
         "command": "logmagnifier.exportTextFilters",
         "title": "Export Text Filters",
         "category": "LogMagnifier",
@@ -2446,6 +2452,14 @@
         },
         {
           "command": "logmagnifier.toggleFileSizeUnit",
+          "when": "false"
+        },
+        {
+          "command": "logmagnifier.exportTextFilters",
+          "when": "false"
+        },
+        {
+          "command": "logmagnifier.exportRegexFilters",
           "when": "false"
         }
       ],

--- a/src/commands/FilterExportImportCommandManager.ts
+++ b/src/commands/FilterExportImportCommandManager.ts
@@ -28,6 +28,7 @@ export class FilterExportImportCommandManager {
     }
 
     private registerCommands() {
+        this.context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.Export, () => this.handleUnifiedExport()));
         this.context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.ExportTextFilters, () => this.handleExport('text')));
         this.context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.ExportRegexFilters, () => this.handleExport('regex')));
         this.context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.ExportGroup, (group: FilterGroup) => this.handleExportGroup(group)));
@@ -36,6 +37,20 @@ export class FilterExportImportCommandManager {
         this.context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.ImportRegexFilters, () => this.handleImport('regex')));
 
         this.registerProfileCommands();
+    }
+
+    /** Shows a QuickPick to choose between text and regex filter export. */
+    private async handleUnifiedExport(): Promise<void> {
+        const choice = await vscode.window.showQuickPick(
+            [
+                { label: '$(symbol-text) Text Filters', description: 'Export word/phrase filters', mode: 'text' as const },
+                { label: '$(regex) Regex Filters', description: 'Export regular expression filters', mode: 'regex' as const }
+            ],
+            { title: 'Export Filters', placeHolder: 'Select filter type to export' }
+        );
+        if (choice) {
+            await this.handleExport(choice.mode);
+        }
     }
 
     /** Shows a multi-select QuickPick for the user to choose groups, then exports them. */

--- a/src/constants/Ids.ts
+++ b/src/constants/Ids.ts
@@ -102,6 +102,7 @@ export const Ids = {
         ToggleOccurrencesHighlight: 'logmagnifier.toggleOccurrencesHighlight',
         ToggleFileSizeUnit: 'logmagnifier.toggleFileSizeUnit',
 
+        Export: 'logmagnifier.export',
         ExportTextFilters: 'logmagnifier.exportTextFilters',
         ImportTextFilters: 'logmagnifier.importTextFilters',
         ExportRegexFilters: 'logmagnifier.exportRegexFilters',


### PR DESCRIPTION
## Summary

- `logmagnifier.export` 커맨드 추가 — Command Palette에서 단일 진입점으로 Text Filters / Regex Filters 중 선택 후 기존 export 플로우로 위임
- `exportTextFilters`, `exportRegexFilters`를 `commandPalette` `when: false`로 숨김 (backward compat 유지, tree view 컨텍스트 메뉴에서는 계속 동작)
- U9 (Filter Tree Inline Icon Actions)는 이미 구현 완료 상태로 확인 — 별도 변경 없음

## Test plan

- [ ] Command Palette에서 "Export Filters..." 검색 → 표시됨 확인
- [ ] "Export Filters..." 실행 → Text Filters / Regex Filters QuickPick 표시 확인
- [ ] 각 항목 선택 시 기존 그룹 선택 QuickPick → 파일 저장 플로우 정상 동작 확인
- [ ] Command Palette에서 "Export Text Filters", "Export Regex Filters" 미표시 확인
- [ ] Filter tree 컨텍스트 메뉴의 Export Group은 여전히 동작 확인
- [ ] `npm test` 609 passing

Closes #263 (U9, U11)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)