### PR TITLE
ux: add regex live validation to filter input boxes (U15)

### DIFF
--- a/src/commands/FilterItemCommandManager.ts
+++ b/src/commands/FilterItemCommandManager.ts
@@ -5,6 +5,7 @@ import { FilterGroup, FilterItem, FilterType } from '../models/Filter';
 
 import { FilterManager } from '../services/FilterManager';
 import { Logger } from '../services/Logger';
+import { RegexUtils } from '../utils/RegexUtils';
 
 export class FilterItemCommandManager {
     constructor(
@@ -78,17 +79,7 @@ export class FilterItemCommandManager {
                 const newPattern = await vscode.window.showInputBox({
                     prompt: Constants.Prompts.EnterRegexPattern,
                     value: item.pattern,
-                    validateInput: (value) => {
-                        if (value.length > Constants.Defaults.MaxPatternLength) {
-                            return Constants.Messages.Error.InputTooLong.replace('{0}', String(Constants.Defaults.MaxPatternLength));
-                        }
-                        try {
-                            new RegExp(value);
-                            return null;
-                        } catch (_e: unknown) {
-                            return Constants.Messages.Error.InvalidRegularExpression;
-                        }
-                    }
+                    validateInput: (value) => RegexUtils.validatePattern(value)
                 });
 
                 if (newPattern === undefined) {
@@ -161,17 +152,7 @@ export class FilterItemCommandManager {
 
             const pattern = await vscode.window.showInputBox({
                 prompt: Constants.Prompts.EnterRegexPattern,
-                validateInput: (value) => {
-                    if (value.length > Constants.Defaults.MaxPatternLength) {
-                        return Constants.Messages.Error.InputTooLong.replace('{0}', String(Constants.Defaults.MaxPatternLength));
-                    }
-                    try {
-                        new RegExp(value);
-                        return null;
-                    } catch (_e: unknown) {
-                        return Constants.Messages.Error.InvalidRegularExpression;
-                    }
-                }
+                validateInput: (value) => RegexUtils.validatePattern(value)
             });
             if (!pattern) {
                 return;

--- a/src/test/utils/RegexUtils.test.ts
+++ b/src/test/utils/RegexUtils.test.ts
@@ -57,4 +57,41 @@ suite('RegexUtils Test Suite', () => {
         // Both should work
         assert.strictEqual(regex1.source, regex2.source);
     });
+
+    suite('validatePattern', () => {
+        test('returns null for valid pattern', () => {
+            assert.strictEqual(RegexUtils.validatePattern('hello.*world'), null);
+        });
+
+        test('returns null for empty string', () => {
+            assert.strictEqual(RegexUtils.validatePattern(''), null);
+        });
+
+        test('returns error for invalid regex syntax', () => {
+            const result = RegexUtils.validatePattern('(unclosed');
+            assert.ok(result !== null, 'Should return error for invalid syntax');
+        });
+
+        test('returns error for pattern exceeding max length', () => {
+            const long = 'a'.repeat(501);
+            const result = RegexUtils.validatePattern(long);
+            assert.ok(result !== null, 'Should return error for too-long pattern');
+            assert.ok(result!.includes('500'), 'Error should mention max length');
+        });
+
+        test('returns error for consecutive quantifiers (ReDoS)', () => {
+            const result = RegexUtils.validatePattern('(a+)+');
+            assert.ok(result !== null, 'Should reject nested quantifiers');
+            assert.ok(result!.includes('performance'), 'Error should mention performance');
+        });
+
+        test('returns error for alternation with quantifier (ReDoS)', () => {
+            const result = RegexUtils.validatePattern('(a|b)+');
+            assert.ok(result !== null, 'Should reject alternation with quantifier');
+        });
+
+        test('returns null for safe alternation', () => {
+            assert.strictEqual(RegexUtils.validatePattern('cat|dog'), null);
+        });
+    });
 });

--- a/src/utils/RegexUtils.ts
+++ b/src/utils/RegexUtils.ts
@@ -5,10 +5,39 @@ export class RegexUtils {
     private static readonly maxCacheSize = Constants.Defaults.RegexCacheSize;
     private static readonly escapeRegex = /[.*+?^${}()|[\]\\]/g;
     private static readonly maxReportedErrors = 200;
+    private static readonly reDoSPatterns = [
+        /(\+|\*|\{)\)?(\+|\*|\{)/,
+        /\([^)]*[+*]\)[+*{]/,
+        /\([^)]*\|[^)]*\)[*+{]/,
+        /\([^)]*[+*][^)]*\|[^)]*\)[*+]/,
+        /(\.\*){2,}/,
+        /\(\.[\*\+]\)\{/,
+    ];
 
     /** Cache stores the 'prototype' RegExp. We clone it to return a fresh instance with its own lastIndex. */
     private static cache: Map<string, RegExp> = new Map();
     private static reportedErrors: Set<string> = new Set();
+
+    /**
+     * Validates a regex pattern for use in validateInput callbacks.
+     * Checks length, ReDoS risk, and syntax.
+     * @returns null if valid, or an error message string if invalid.
+     */
+    public static validatePattern(pattern: string): string | null {
+        const max = Constants.Defaults.MaxPatternLength;
+        if (pattern.length > max) {
+            return Constants.Messages.Error.InputTooLong.replace('{0}', String(max));
+        }
+        if (RegexUtils.reDoSPatterns.some(p => p.test(pattern))) {
+            return 'Pattern may cause performance issues (nested quantifiers)';
+        }
+        try {
+            new RegExp(pattern);
+            return null;
+        } catch (e: unknown) {
+            return e instanceof Error ? e.message : String(e);
+        }
+    }
 
     /**
      * Creates a RegExp object safely with caching.
@@ -33,20 +62,10 @@ export class RegexUtils {
             const flags = caseSensitive ? 'g' : 'gi';
             let regex: RegExp;
             if (isRegex) {
-                // Reject patterns that may cause catastrophic backtracking (ReDoS)
-                const MAX_REGEX_LENGTH = 500;
-                const REDOS_PATTERNS = [
-                    /(\+|\*|\{)\)?(\+|\*|\{)/,       // consecutive quantifiers: (a+)+, a**
-                    /\([^)]*[+*]\)[+*{]/,             // group+quantifier combo: (a+)+, (a|b)*{2}
-                    /\([^)]*\|[^)]*\)[*+{]/,          // alternation with quantifier: (a|b)+
-                    /\([^)]*[+*][^)]*\|[^)]*\)[*+]/,  // overlap in alternation: (a+|a)*
-                    /(\.\*){2,}/,                      // multiple greedy wildcards: .*.*
-                    /\(\.[\*\+]\)\{/,                  // dot-star/plus in group with repetition: (.*){n}
-                ];
-                if (pattern.length > MAX_REGEX_LENGTH) {
+                if (pattern.length > Constants.Defaults.MaxPatternLength) {
                     throw new Error('Pattern too long');
                 }
-                if (REDOS_PATTERNS.some(p => p.test(pattern))) {
+                if (RegexUtils.reDoSPatterns.some(p => p.test(pattern))) {
                     throw new Error('Pattern contains nested quantifiers that may cause performance issues');
                 }
                 regex = new RegExp(pattern, flags);


### PR DESCRIPTION
## Summary

- `RegexUtils.validatePattern()` 헬퍼 추가 — 길이, ReDoS 위험(중첩 수량자), 문법 오류를 통합 검증
- `FilterItemCommandManager`의 regex 입력 박스 두 곳(add, edit)에서 중복된 인라인 `try/new RegExp()` 검증을 `RegexUtils.validatePattern()`으로 교체
- 기존 `create()`의 ReDoS 패턴을 클래스 상수 `reDoSPatterns`로 추출하여 재사용

## 변경 내용

| 항목 | 이전 | 이후 |
|---|---|---|
| Add Regex Filter | `new RegExp()` 문법만 검사 | 길이 + ReDoS + 문법 |
| Edit Regex Filter | `new RegExp()` 문법만 검사 | 길이 + ReDoS + 문법 |

## Test plan

- [ ] Regex Filter 추가 시 유효하지 않은 패턴(`(unclosed`) 입력 → 즉시 오류 메시지 표시
- [ ] ReDoS 위험 패턴(`(a+)+`, `(a|b)+`) 입력 → "performance" 관련 경고 표시
- [ ] 501자 이상 입력 → 길이 초과 오류 표시
- [ ] 정상 패턴(`hello.*world`) → 오류 없이 통과
- [ ] Regex Filter 편집(Rename...)에서도 동일하게 동작
- [ ] `npm test` 616 passing

Closes #263 (U15)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)