### PR TITLE
ux: add cancellable progress UI for large-file processing (U16)

### DIFF
--- a/src/commands/FilterExecutionCommandManager.ts
+++ b/src/commands/FilterExecutionCommandManager.ts
@@ -122,8 +122,8 @@ export class FilterExecutionCommandManager {
             await vscode.window.withProgress({
                 location: vscode.ProgressLocation.Notification,
                 title: `Applying ${filterType || ''} Filters on ${sourceName}...`,
-                cancellable: false
-            }, async (_progress) => {
+                cancellable: true
+            }, async (progress, token) => {
                 try {
                     const targetPath = filePathFromTab || document?.uri.fsPath;
 
@@ -140,7 +140,17 @@ export class FilterExecutionCommandManager {
                     const result = await this.logProcessor.processFile(targetPath, activeGroups, {
                         prependLineNumbers: this.prependLineNumbersEnabled,
                         totalLineCount: totalLineCount,
-                        content: document ? document.getText() : undefined
+                        content: document ? document.getText() : undefined,
+                        token,
+                        onProgress: (processed, total) => {
+                            const knownTotal = document && total === document.lineCount;
+                            const pct = knownTotal
+                                ? Math.min(Math.floor(processed / total * 100), 99)
+                                : undefined;
+                            progress.report({
+                                message: pct !== undefined ? `${pct}%` : `${processed.toLocaleString()} lines...`
+                            });
+                        }
                     });
                     outputPath = result.outputPath;
                     stats.processed = result.processed;
@@ -159,6 +169,9 @@ export class FilterExecutionCommandManager {
                         this.lineMappingService.register(outputUri, sourceUri, result.lineMapping);
                     }
                 } catch (e: unknown) {
+                    if (e instanceof vscode.CancellationError) {
+                        return;
+                    }
                     vscode.window.showErrorMessage(Constants.Messages.Error.ApplyFiltersError.replace('{0}', e instanceof Error ? e.message : String(e)));
                     return;
                 }

--- a/src/services/LogProcessor.ts
+++ b/src/services/LogProcessor.ts
@@ -69,7 +69,7 @@ export class LogProcessor {
      * @returns Promise resolving to output path and statistics
      * @throws Error if file cannot be read or written
      */
-    public async processFile(inputPath: string, filterGroups: FilterGroup[], options?: { prependLineNumbers?: boolean, totalLineCount?: number, originalPath?: string, mergeGroups?: boolean, content?: string }): Promise<{ outputPath: string, processed: number, matched: number, lineMapping: number[] }> {
+    public async processFile(inputPath: string, filterGroups: FilterGroup[], options?: { prependLineNumbers?: boolean, totalLineCount?: number, originalPath?: string, mergeGroups?: boolean, content?: string, token?: vscode.CancellationToken, onProgress?: (processed: number, total: number) => void }): Promise<{ outputPath: string, processed: number, matched: number, lineMapping: number[] }> {
         const inputStream: Readable = options?.content !== undefined
             ? Readable.from(options.content)
             : fs.createReadStream(inputPath, { encoding: 'utf8' });
@@ -148,9 +148,24 @@ export class LogProcessor {
             return ok;
         };
 
+        const token = options?.token;
+        const onProgress = options?.onProgress;
+        const reportTotal = options?.totalLineCount || DEFAULT_MAX_LINE_COUNT;
+        const PROGRESS_INTERVAL = 5000;
+
         const processLines = async () => {
             for await (const line of rl) {
                 processed++; // 1-based index
+
+                if (processed % PROGRESS_INTERVAL === 0) {
+                    if (token?.isCancellationRequested) {
+                        rl.close();
+                        outputStream.destroy();
+                        throw new vscode.CancellationError();
+                    }
+                    onProgress?.(processed, reportTotal);
+                }
+
                 const matchResult = this.checkMatchCompiled(line, compiledGroups);
 
                 if (matchResult.isMatched) {
@@ -202,7 +217,15 @@ export class LogProcessor {
         };
 
         // Race: process lines vs stream errors
-        await Promise.race([processLines(), streamError]);
+        try {
+            await Promise.race([processLines(), streamError]);
+        } catch (e: unknown) {
+            if (e instanceof vscode.CancellationError) {
+                fs.unlink(outputPath, () => { /* best-effort cleanup */ });
+                throw e;
+            }
+            throw e;
+        }
 
         // Adjust mapping to be 0-based for VS Code Positions
         const adjustedMapping = lineMapping.map(l => l - 1);

--- a/src/services/WorkflowManager.ts
+++ b/src/services/WorkflowManager.ts
@@ -842,8 +842,9 @@ export class WorkflowManager implements vscode.Disposable {
                     // Run LogProcessor
                     const result = await this.logProcessor.processFile(inputFile, effectiveGroups, {
                         prependLineNumbers: false,
-                        totalLineCount: lineCount, // pass 0 or real count
-                        mergeGroups: true // Always use Union logic for multiple profiles/levels
+                        totalLineCount: lineCount,
+                        mergeGroups: true,
+                        token
                     });
 
                     // Track file


### PR DESCRIPTION
## Summary

- `LogProcessor.processFile()` 옵션에 `token`(취소)과 `onProgress`(진행률 콜백) 추가
- 내부 루프에서 5000줄마다 취소 요청 확인 → 취소 시 임시 파일 정리 후 `CancellationError` throw
- `FilterExecutionCommandManager`: `cancellable: false` → `true`로 변경, token/onProgress 연결
  - 문서 라인 수를 알 때: `37%` 형태 퍼센트 표시
  - 파일 직접 처리 시: `12,345 lines...` 형태 표시
  - 사용자 취소 시 에러 토스트 없이 조용히 종료
- `WorkflowManager`: 기존 workflow 취소 token을 `processFile()` 호출로 전달 (단계 취소 propagation)

## Test plan

- [ ] 대용량 파일(50MB+)에서 Apply Filter 실행 → 진행률 알림 표시 확인
- [ ] 알림의 취소 버튼 클릭 → 처리 중단, 에러 토스트 없음, 임시 파일 잔류 없음 확인
- [ ] 문서 열린 상태: 퍼센트(%) 표시 확인
- [ ] 파일 탭 직접 처리 시: 줄 수 표시 확인
- [ ] Workflow 실행 중 취소 → 현재 처리 단계도 함께 취소 확인
- [ ] `npm test` 609 passing

Closes #263 (U16)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)