### PR TITLE
workflow: fix welcome screen links not responding to clicks

### DIFF
--- a/resources/webview/workflow-tree-template.html
+++ b/resources/webview/workflow-tree-template.html
@@ -361,14 +361,16 @@
                         <div style="padding: 20px 24px; color: var(--vscode-foreground); font-size: 13px; line-height: 1.6;">
                             <p style="margin: 0 0 12px;">No workflows yet.</p>
                             <p style="margin: 0 0 6px;">
-                                <a href="#" onclick="post('create',{}); return false;"
+                                <a href="#" id="welcome-create"
                                    style="color: var(--vscode-textLink-foreground); text-decoration: none;">New Workflow</a>
                             </p>
                             <p style="margin: 0;">
-                                <a href="#" onclick="post('import',{}); return false;"
+                                <a href="#" id="welcome-import"
                                    style="color: var(--vscode-textLink-foreground); text-decoration: none;">Import Workflow</a>
                             </p>
                         </div>`;
+                    document.getElementById('welcome-create')?.addEventListener('click', (e) => { e.preventDefault(); post('create', {}); });
+                    document.getElementById('welcome-import')?.addEventListener('click', (e) => { e.preventDefault(); post('import', {}); });
                     return;
                 }
 

--- a/src/models/WebviewModels.ts
+++ b/src/models/WebviewModels.ts
@@ -25,6 +25,7 @@ export interface SerializedBookmarkItem {
 }
 
 export type WorkflowWebviewMessage =
+    | { type: 'create' }
     | { type: 'import' }
     | { type: 'export' }
     | { type: 'run'; id: string }

--- a/src/views/WorkflowWebviewProvider.ts
+++ b/src/views/WorkflowWebviewProvider.ts
@@ -103,6 +103,7 @@ export class WorkflowWebviewProvider implements vscode.WebviewViewProvider, vsco
 
     private async handleMessage(data: WorkflowWebviewMessage): Promise<void> {
         switch (data.type) {
+            case 'create': return this.handleCreate();
             case 'import': return this.handleImport();
             case 'export': return this.handleExport();
             case 'run': return this.handleRun(data);
@@ -119,6 +120,10 @@ export class WorkflowWebviewProvider implements vscode.WebviewViewProvider, vsco
             case 'moveStepUp': return this.handleMoveStep(data, 'up');
             case 'moveStepDown': return this.handleMoveStep(data, 'down');
         }
+    }
+
+    private async handleCreate(): Promise<void> {
+        await vscode.commands.executeCommand(Constants.Commands.WorkflowCreate);
     }
 
     private async handleImport(): Promise<void> {


### PR DESCRIPTION
## Summary

Workflow 뷰 빈 상태 welcome 화면의 **New Workflow** / **Import Workflow** 링크 클릭 시 아무 동작도 하지 않는 버그 수정.

**원인:** 웹뷰 템플릿에서 `post('create', {})` 메시지를 전송하지만, `WorkflowWebviewProvider.handleMessage()`에 `'create'` case가 없어 무시됨.

**수정:**
- `WorkflowWebviewMessage` 타입에 `{ type: 'create' }` 추가
- `handleMessage()`에 `'create'` case 추가
- `handleCreate()` 메서드 추가 → `WorkflowCreate` 커맨드 실행

## Test plan

- [ ] Workflow 뷰가 비어 있을 때 **New Workflow** 클릭 → 워크플로우 이름 입력 창 표시 확인
- [ ] **Import Workflow** 클릭 → 파일 선택 다이얼로그 표시 확인
- [ ] `npm test` 616 passing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)