### PR TITLE
ui: shrink sidebar view welcome screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1144,15 +1144,15 @@
     "viewsWelcome": [
       {
         "view": "logmagnifier-text-filters",
-        "contents": "No text filters yet.\n[Add Group](command:logmagnifier.addTextFilterGroup)\n[Import Filters](command:logmagnifier.importTextFilters)"
+        "contents": "No text filters yet. [Add Group](command:logmagnifier.addTextFilterGroup) · [Import](command:logmagnifier.importTextFilters)"
       },
       {
         "view": "logmagnifier-regex-filters",
-        "contents": "No regex filters yet.\n[Add Group](command:logmagnifier.addRegexFilterGroup)\n[Import Filters](command:logmagnifier.importRegexFilters)"
+        "contents": "No regex filters yet. [Add Group](command:logmagnifier.addRegexFilterGroup) · [Import](command:logmagnifier.importRegexFilters)"
       },
       {
         "view": "logmagnifier-runbook",
-        "contents": "No runbook entries yet.\n[Add Group](command:logmagnifier.runbook.addGroup)\n[Import Runbook](command:logmagnifier.runbook.import)"
+        "contents": "No runbook entries yet. [Add Group](command:logmagnifier.runbook.addGroup) · [Import](command:logmagnifier.runbook.import)"
       },
       {
         "view": "logmagnifier-time-range",

--- a/resources/webview/workflow-tree-template.html
+++ b/resources/webview/workflow-tree-template.html
@@ -358,16 +358,13 @@
 
                 if (!workflows || workflows.length === 0) {
                     container.innerHTML = `
-                        <div style="padding: 20px 24px; color: var(--vscode-foreground); font-size: 13px; line-height: 1.6;">
-                            <p style="margin: 0 0 12px;">No workflows yet.</p>
-                            <p style="margin: 0 0 6px;">
-                                <a href="#" id="welcome-create"
-                                   style="color: var(--vscode-textLink-foreground); text-decoration: none;">New Workflow</a>
-                            </p>
-                            <p style="margin: 0;">
-                                <a href="#" id="welcome-import"
-                                   style="color: var(--vscode-textLink-foreground); text-decoration: none;">Import Workflow</a>
-                            </p>
+                        <div style="padding: 6px 12px; color: var(--vscode-foreground); font-size: 13px; line-height: 1.4;">
+                            No workflows yet.
+                            <a href="#" id="welcome-create"
+                               style="color: var(--vscode-textLink-foreground); text-decoration: none;">New</a>
+                            ·
+                            <a href="#" id="welcome-import"
+                               style="color: var(--vscode-textLink-foreground); text-decoration: none;">Import</a>
                         </div>`;
                     document.getElementById('welcome-create')?.addEventListener('click', (e) => { e.preventDefault(); post('create', {}); });
                     document.getElementById('welcome-import')?.addEventListener('click', (e) => { e.preventDefault(); post('import', {}); });


### PR DESCRIPTION
## Summary
- Workflows, Runbook, Text Filters, and Regex Filters welcome screens each occupied more vertical space than the view's minimum resize height, preventing users from collapsing those views to give space to siblings.
- Workflows webview: collapsed the three padded paragraphs into a single inline line and reduced padding from 20px/24px to 6px/12px.
- Runbook / Text Filters / Regex Filters: moved the action links onto the placeholder line so VS Code renders them as inline links instead of stacked full-width command buttons.

## Test plan
- [ ] Open the LogMagnifier sidebar with no workflows / no runbook / no filters configured.
- [ ] Confirm each empty view's welcome fits within the view's minimum row height.
- [ ] Drag dividers to shrink each view and confirm welcome content no longer forces a larger minimum.
- [ ] Click each link (New / Import / Add Group) and confirm the corresponding command still fires.