### PR TITLE
filter: seed regex Presets only on first run

### DIFF
--- a/src/constants/Ids.ts
+++ b/src/constants/Ids.ts
@@ -311,6 +311,7 @@ export const Ids = {
         BookmarkFileOrder: 'logmagnifier.bookmarks_fileOrder',
         Workflows: 'logmagnifier.workflows',
         ActiveWorkflow: 'logmagnifier.activeWorkflow',
+        DefaultRegexPresetsSeeded: 'logmagnifier.defaultRegexPresetsSeeded',
     },
 
     Defaults: {

--- a/src/services/FilterManager.ts
+++ b/src/services/FilterManager.ts
@@ -39,7 +39,15 @@ export class FilterManager implements vscode.Disposable {
 
         this.groups = this.stateService.loadFromState();
         this.resetCounts();
-        this.initDefaultFilters();
+
+        // Seed the default Presets group only on first run. Once seeded, a user
+        // who deletes the group must not have it auto-restored on restart;
+        // clearRegexGroups() bypasses this flag to honor the explicit reset command.
+        const seeded = this.context.globalState.get<boolean>(Constants.GlobalState.DefaultRegexPresetsSeeded, false);
+        if (!seeded) {
+            this.initDefaultFilters();
+            this.context.globalState.update(Constants.GlobalState.DefaultRegexPresetsSeeded, true);
+        }
 
         // Relay profile changes & Reload filters
         this.profileDisposable = this.profileManager.onDidChangeProfile(async () => {

--- a/src/test/services/FilterManager.test.ts
+++ b/src/test/services/FilterManager.test.ts
@@ -351,3 +351,57 @@ suite('FilterManager Clear Groups Test Suite', () => {
         assert.strictEqual(groups.length, 0, 'No groups should exist after removing the only group');
     });
 });
+
+suite('FilterManager Default Presets Seeding', () => {
+    test('First construction seeds default Presets group', () => {
+        const ctx = new MockExtensionContext();
+        const fm = new FilterManager(ctx);
+        try {
+            const presets = fm.getGroups().find(g => g.name === 'Presets');
+            assert.ok(presets, 'Presets should be seeded on first run');
+            assert.strictEqual(presets.isRegex, true);
+        } finally {
+            fm.dispose();
+        }
+    });
+
+    test('Reconstruction with same context does not re-seed Presets after deletion', () => {
+        const ctx = new MockExtensionContext();
+
+        const fm1 = new FilterManager(ctx);
+        const presets = fm1.getGroups().find(g => g.name === 'Presets');
+        assert.ok(presets, 'Setup: Presets should exist after first construction');
+        fm1.removeGroup(presets.id);
+        assert.strictEqual(fm1.getGroups().length, 0, 'All groups removed before dispose');
+        fm1.dispose();
+
+        const fm2 = new FilterManager(ctx);
+        try {
+            assert.strictEqual(fm2.getGroups().length, 0,
+                'Presets must not be auto-restored after deletion + restart');
+        } finally {
+            fm2.dispose();
+        }
+    });
+
+    test('clearRegexGroups restores Presets even when seeded flag is set', () => {
+        const ctx = new MockExtensionContext();
+
+        const fm1 = new FilterManager(ctx);
+        const initial = fm1.getGroups().find(g => g.name === 'Presets');
+        assert.ok(initial, 'Setup: Presets seeded');
+        fm1.removeGroup(initial.id);
+        fm1.dispose();
+
+        const fm2 = new FilterManager(ctx);
+        try {
+            assert.strictEqual(fm2.getGroups().length, 0, 'Setup: groups empty after restart');
+            fm2.clearRegexGroups();
+            const restored = fm2.getGroups().find(g => g.name === 'Presets');
+            assert.ok(restored, 'clearRegexGroups must restore Presets regardless of seeded flag');
+            assert.strictEqual(restored.filters.length, 2);
+        } finally {
+            fm2.dispose();
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- The default regex `Presets` group was re-seeded on every extension startup whenever no regex group existed in storage, so deleting the group only stuck until the next window reload.
- Track a `DefaultRegexPresetsSeeded` flag in `globalState` and seed defaults in the `FilterManager` constructor exactly once per install. After the first run, deletion of the Presets group persists across restarts.
- The `clearRegexFilterData` command path is unchanged — it calls `initDefaultFilters()` directly without checking the flag, so an explicit reset still restores the defaults.

## Spec
1. First install shows the default preset — covered by first-run seeding.
2. Deleting the default preset does not auto-restore it — fixed by the flag.
3. `clearRegexFilterData` reset shows the default preset again — preserved (direct call bypasses the flag).

## Test plan
- [x] `npm test` — 622 passing, including 3 new regression tests in `FilterManager Default Presets Seeding`.
- [ ] Manual: fresh install → Presets appears.
- [ ] Manual: delete Presets → reload window → Presets stays gone.
- [ ] Manual: run `LogMagnifier: Clear Regex Filter Data` → Presets is restored.
- [ ] Manual: after step above, delete Presets again → reload → still gone.