### PR TITLE
Release v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [1.7.3]
 
+### Added
+- **Welcome Views**: Empty Text Filters, Regex Filters, Runbook, Time Range, and Workflows views now display CTA links (Add / Import / Open) so first-time users have a clear entry point.
+- **Cross-Platform Keybindings**: All `Ctrl+Cmd+*` shortcuts now also bind to `Ctrl+Alt+*` on Windows/Linux. Affected commands: Go to Timestamp, JSON Preview, File Hierarchy Tree, Next/Previous Match.
+- **Unified Export**: Added a single `LogMagnifier: Export` command palette entry that prompts for Text or Regex Filters; the per-type export commands are hidden from the palette but still available via title bar buttons.
+- **Regex Live Validation**: Filter input boxes now validate regex patterns inline (length, ReDoS heuristics, syntax) via the new `RegexUtils.validatePattern()` helper.
+- **Cancellable Progress**: Apply Filter and Workflow runs on large files now show a cancellable progress notification with percentage or processed-line count. Cancelling cleans up the partial temp file.
+
 ### Fixed
 - **Tool Input**: `extractLogsWithMargin` now rejects non-finite and out-of-range `marginSeconds` (negative or above 24 hours) before attempting time math, preventing downstream overflow from unbounded inputs.
 - **Hierarchy**: `FileHierarchyService` keys file:// URIs case-insensitively on macOS/Windows so mixed-case paths no longer produce duplicate hierarchy entries; legacy unnormalized keys are normalized on load.
@@ -9,9 +16,12 @@
 - **Webview**: Replaced the inline JSON `<\/` escape in the bookmark webview with the shared `safeJson()` helper so escaping is consistent with other webviews.
 - **Logging**: `WebviewUtils.safeJson()` now logs serialization failures instead of silently returning `'null'`.
 - **UX**: Filter execution and profile-manager relay failures are now surfaced via a warning popup instead of being logger-only.
+- **Workflow Welcome**: New Workflow / Import Workflow links in the empty-state webview were silently ignored due to a missing message handler and a CSP-blocked inline `onclick`. Both are now wired up via nonce-compliant `addEventListener`.
+- **Regex Presets**: The default Presets group is now seeded only once per install. Users who delete the Presets group no longer see it reappear on every window reload; the explicit `Clear Regex Filter Data` command still restores defaults.
 
 ### Changed
 - **AI Tools**: `SearchLogTool` now exposes a `prepareInvocation` summary consistent with the other Language Model Tools.
+- **Sidebar Welcome**: Welcome content for Workflows, Runbook, Text Filters, and Regex Filters was reduced to a single inline line so users can now collapse those views to make room for siblings.
 - **Style**: Import grouping in `extension.ts`, class-member ordering in the command managers, and drag/drop MIME declarations in `FilterTreeDataProvider` now match `.agent/rules/code-style.md`. LRU-eviction sites carry explanatory comments.
 
 ## [1.7.2]

--- a/README.md
+++ b/README.md
@@ -47,18 +47,18 @@ A powerful log analysis tool for Visual Studio Code, featuring advanced log filt
   - **Persistence**: Bookmarks are saved and restored across sessions.
 - **Log Analysis Workflows**: Automated, multi-step log analysis by chaining multiple filter profiles.
 - **Runbook**: Manage and execute operational runbooks via an interactive, Markdown-based notebook interface with real-time webview output. Write documentation alongside executable shell code blocks, stop long-running commands, edit scripts inline, and share configurations via import/export.
-- **Interactive JSON Preview**: Extract and explore JSON objects from log lines in a dedicated, searchable tree view (Ctrl+Cmd+J).
+- **Interactive JSON Preview**: Extract and explore JSON objects from log lines in a dedicated, searchable tree view (`Ctrl+Cmd+J` on macOS, `Ctrl+Alt+J` on Windows/Linux).
   - **Depth Control**: Incrementally expand or collapse JSON structure levels with persistent depth state.
 - **Timestamp Analysis**: Automatic timestamp detection and time-based log navigation.
   - **Auto Detection**: Recognizes 8 built-in formats (ISO 8601, Apache, syslog, Android logcat, etc.).
   - **Time Range Explorer**: Hierarchical tree view (hour → 10min → minute) with density bar icons.
   - **Time Range Extract**: Extract log segments by time range via tree or editor context menus.
-  - **Go to Timestamp**: Jump to a specific time (`Ctrl+Cmd+G`) with absolute (`HH:MM:SS`) or relative (`+5m`, `-30s`) input.
+  - **Go to Timestamp**: Jump to a specific time (`Ctrl+Cmd+G` on macOS, `Ctrl+Alt+G` on Windows/Linux) with absolute (`HH:MM:SS`) or relative (`+5m`, `-30s`) input.
   - **Selection Gap Display**: Select multiple lines to see time gaps — gutter icons mark gaps, hover shows duration, status bar summarizes the selection.
 - **AI Agent Integration**: Language Model Tools for GitHub Copilot Agent Mode — control filters, profiles, workflows, bookmarks, timestamps, and JSON extraction via natural language (`#logmagnifier` tool set).
 - **File Hierarchy & Navigation**: Persistent tracking of relationships between original logs, filtered views, and bookmarks.
   - **CodeLens**: clickable "Original" and "Parent" links automatically appear at the top of filtered files.
-  - **Tree View**: Visualize the full hierarchy (Original -> Filter -> Bookmark) in an indented tree (Ctrl+Cmd+T).
+  - **Tree View**: Visualize the full hierarchy (Original -> Filter -> Bookmark) in an indented tree (`Ctrl+Cmd+T` on macOS, `Ctrl+Alt+T` on Windows/Linux).
   - **Management**: Quickly remove items using the trash icon, with support for recursive deletion (deleting a root file removes all its derivatives).
   - **Persistence**: Navigation links and hierarchy are preserved even after restarting VS Code.
 
@@ -94,7 +94,7 @@ A powerful log analysis tool for Visual Studio Code, featuring advanced log filt
     - *Tip*: Select text in the editor, right-click, and choose **Add Selection to LogMagnifier** to instantly create a filter.
     - *Tip*: Right-click items to access organized options like **Filter Type**, **Case Sensitivity**, **Highlight Mode**, and **Context Lines**.
     - *Tip*: Click the **Arrow Up/Down** icons on a filter item to navigate to the previous or next match in the editor.
-    - *Tip*: Use keyboard shortcuts **`Ctrl + Cmd + ]`** (Next) and **`Ctrl + Cmd + [`** (Previous) to navigate matches of the selected filter.
+    - *Tip*: Use keyboard shortcuts **`Ctrl+Cmd+]`** / **`Ctrl+Cmd+[`** on macOS (or **`Ctrl+Alt+]`** / **`Ctrl+Alt+[`** on Windows/Linux) to navigate Next / Previous matches of the selected filter.
 5. **Apply**: Click the **Play** icon in the view title to generate filtered results.
     - *Tip*: Toggle the **List Icon** in the view title to include original line numbers in the output.
 6. **Dashboard**: Use the **Dashboard** view to toggle editor settings (Word Wrap, Minimap, Sticky Scroll) or check the current file size.
@@ -160,7 +160,7 @@ A powerful log analysis tool for Visual Studio Code, featuring advanced log filt
 
 ![JSON Preview Demo](resources/demo/json-preview.gif)
 
-1.  **Open**: Press `Ctrl+Cmd+J` on a log line containing a JSON object to extract and display it in the JSON Preview view.
+1.  **Open**: Press `Ctrl+Cmd+J` (macOS) or `Ctrl+Alt+J` (Windows/Linux) on a log line containing a JSON object to extract and display it in the JSON Preview view.
 2.  **Explore**: Expand or collapse nodes in the tree view to navigate the JSON structure.
 3.  **Depth Control**: Use the **+/-** icons to incrementally expand or collapse all nodes by one level at a time.
 4.  **Search**: Use the search box to filter visible nodes by key or value.
@@ -173,7 +173,7 @@ A powerful log analysis tool for Visual Studio Code, featuring advanced log filt
     - Right-click a tree node → **Extract This Time → End** or **Extract Start → This Time**.
     - Right-click in the editor → **Extract This Line → End** or **Extract Start → This Line**.
     - **Extract This Range** / **Extract Range ± Margin...** to extract a specific time window.
-4.  **Go to Timestamp**: Press `Ctrl+Cmd+G` (or click the status bar) to jump to a specific time. Supports absolute (`14:30`, `14:30:05.123`) and relative (`+5m`, `-30s`) input.
+4.  **Go to Timestamp**: Press `Ctrl+Cmd+G` (macOS) or `Ctrl+Alt+G` (Windows/Linux), or click the status bar, to jump to a specific time. Supports absolute (`14:30`, `14:30:05.123`) and relative (`+5m`, `-30s`) input.
 5.  **Selection Gap Display**: Select multiple lines to analyze time gaps — clock icons appear in the gutter at gap locations, hover for details, and the status bar shows a summary.
 6.  **Settings**: Configure via `logmagnifier.timestamp.enabled`, `autoDetect`, `customPatterns`, and `gapThreshold`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "logmagnifier",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logmagnifier",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "marked": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "logmagnifier",
   "displayName": "LogMagnifier",
   "description": "A full-focus log analysis tool for Visual Studio Code, featuring advanced filtering, highlighting, timestamp analysis, and AI agent integration.",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "author": "webispy@gmail.com",
   "publisher": "webispy",
   "icon": "icon.png",


### PR DESCRIPTION
## Summary
- Bumps version to **1.7.3** with five sidebar/UX improvements and follow-ups from the post-v1.7.2 self-review.
- Updates `CHANGELOG.md` with full Added/Fixed/Changed entries and surfaces the new `Ctrl+Alt+*` Windows/Linux keybinding fallbacks in `README.md`.

## Highlights
- **Welcome views**: CTA links for empty Text/Regex Filters, Runbook, Time Range, and Workflows; sidebars are now collapsible (welcome content shrunk to inline).
- **Cross-platform keybindings**: `Ctrl+Cmd+*` shortcuts now also bind to `Ctrl+Alt+*` on Windows/Linux (Go to Timestamp, JSON Preview, File Hierarchy Tree, Next/Previous Match).
- **Unified Export**: single `LogMagnifier: Export` palette command that prompts for Text or Regex Filters.
- **Regex live validation**: length / ReDoS / syntax checks via `RegexUtils.validatePattern()`.
- **Cancellable progress**: Apply Filter and Workflow runs on large files now show a cancellable progress notification with percentage or processed-line count.
- **Fixes**: Workflow welcome links (CSP + missing handler), Regex Presets reappearing after deletion, hardened `extractLogsWithMargin` bounds, case-insensitive hierarchy URI keys, deduped regex error popups, consistent webview JSON escaping, surfaced silent failures.

## Test plan
- [x] `rm -rf out/ dist/ && npm test` → 622 passing
- [ ] Manual smoke: empty welcome views render with working CTA links on all four sidebars
- [ ] Manual smoke: `Ctrl+Alt+G` / `Ctrl+Alt+J` / `Ctrl+Alt+T` / `Ctrl+Alt+]` / `Ctrl+Alt+[` work on Windows or Linux
- [ ] Manual smoke: Apply Filter on a large file shows a cancellable progress notification; cancel cleans up the partial temp file
- [ ] Manual smoke: delete the Regex Presets group, reload window — Presets stays gone; `Clear Regex Filter Data` still restores defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)